### PR TITLE
Add a dirty chunks overlay for debugging misbehaving mods

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,20 @@ Does VisualProspecting run with other maps? - I runs just fine, but it has no vi
  - [TheLastKumquat](https://github.com/kumquat-ir) integrated XaeroWorldMap and XaeroMiniMap
  - [glowredman](https://github.com/glowredman) integrated VoxelMap
 
+### Developer overlays
+
+VisualProspecting comes with developer overlays for debugging chunk saving issues, to activate it change the following config setting in `config/visualprospecting.cfg` to true:
+
+```
+B:enableDeveloperOverlays=true
+```
+
+The dirty chunk overlay works only in singleplayer mode in JourneyMap, and displays which chunks are marked as "dirty" in the game engine.
+This can be used to debug mods that don't set this flag properly and therefore lose data or duplicate items on world load/unload.
+
+![Dirty chunks in JourneyMap developer overlay](https://i.ibb.co/XX1hqS5/2022-03-30-18-06-56.png) \
+_Dirty chunks in JourneyMap developer overlay_
+
 ### Dependencies
 
 #### Required Mods:

--- a/src/main/java/com/sinthoras/visualprospecting/Config.java
+++ b/src/main/java/com/sinthoras/visualprospecting/Config.java
@@ -19,6 +19,7 @@ public class Config {
         public static final int maxTransferCacheSizeMB = 50;
         public static final boolean enableVoxelMapWaypointsByDefault = false;
         public static final int maxDimensionSizeMBForFastScanning = 10000;
+        public static boolean enableDeveloperOverlays = false;
     }
 
     private static class Categories {
@@ -39,6 +40,7 @@ public class Config {
     public static int maxTransferCacheSizeMB = Defaults.maxTransferCacheSizeMB;
     public static boolean enableVoxelMapWaypointsByDefault = Defaults.enableVoxelMapWaypointsByDefault;
     public static int maxDimensionSizeMBForFastScanning = Defaults.maxDimensionSizeMBForFastScanning;
+    public static boolean enableDeveloperOverlays = Defaults.enableDeveloperOverlays;
 
 
     public static void syncronizeConfiguration(File configFile) {
@@ -95,6 +97,10 @@ public class Config {
                         "dimension in MB that can be processed in a single pass. Reduce this number if you run into " +
                         "memory issues during the initial world scan (OutOfMemoryException).");
         maxDimensionSizeMBForFastScanning = maxDimensionSizeMBForFastScanningProperty.getInt();
+
+        Property enableDeveloperOverlaysProperty = configuration.get(Categories.general, "enableDeveloperOverlays",
+                Defaults.enableDeveloperOverlays, "[CLIENT] Enable mod developer overlays, not useful for gameplay");
+        enableDeveloperOverlays = enableDeveloperOverlaysProperty.getBoolean();
 
         if(configuration.hasChanged()) {
             configuration.save();

--- a/src/main/java/com/sinthoras/visualprospecting/integration/journeymap/JourneyMapState.java
+++ b/src/main/java/com/sinthoras/visualprospecting/integration/journeymap/JourneyMapState.java
@@ -1,9 +1,7 @@
 package com.sinthoras.visualprospecting.integration.journeymap;
 
-import com.sinthoras.visualprospecting.integration.journeymap.buttons.LayerButton;
-import com.sinthoras.visualprospecting.integration.journeymap.buttons.OreVeinButton;
-import com.sinthoras.visualprospecting.integration.journeymap.buttons.ThaumcraftNodeButton;
-import com.sinthoras.visualprospecting.integration.journeymap.buttons.UndergroundFluidButton;
+import com.sinthoras.visualprospecting.Config;
+import com.sinthoras.visualprospecting.integration.journeymap.buttons.*;
 import com.sinthoras.visualprospecting.integration.journeymap.render.*;
 import com.sinthoras.visualprospecting.integration.journeymap.waypoints.OreVeinWaypointManager;
 import com.sinthoras.visualprospecting.integration.journeymap.waypoints.ThaumcraftNodeWaypointManager;
@@ -38,6 +36,11 @@ public class JourneyMapState {
         buttons.add(OreVeinButton.instance);
         renderers.add(OreVeinRenderer.instance);
         waypointManagers.add(OreVeinWaypointManager.instance);
+
+        if(Config.enableDeveloperOverlays) {
+            buttons.add(DirtyChunkButton.instance);
+            renderers.add(DirtyChunkRenderer.instance);
+        }
     }
 
     public void openJourneyMapAt(int blockX, int blockZ) {

--- a/src/main/java/com/sinthoras/visualprospecting/integration/journeymap/buttons/DirtyChunkButton.java
+++ b/src/main/java/com/sinthoras/visualprospecting/integration/journeymap/buttons/DirtyChunkButton.java
@@ -1,0 +1,12 @@
+package com.sinthoras.visualprospecting.integration.journeymap.buttons;
+
+import com.sinthoras.visualprospecting.integration.model.buttons.DirtyChunkButtonManager;
+
+public class DirtyChunkButton extends LayerButton {
+
+    public static final DirtyChunkButton instance = new DirtyChunkButton();
+
+    public DirtyChunkButton() {
+        super(DirtyChunkButtonManager.instance);
+    }
+}

--- a/src/main/java/com/sinthoras/visualprospecting/integration/journeymap/drawsteps/DirtyChunkDrawStep.java
+++ b/src/main/java/com/sinthoras/visualprospecting/integration/journeymap/drawsteps/DirtyChunkDrawStep.java
@@ -1,0 +1,46 @@
+package com.sinthoras.visualprospecting.integration.journeymap.drawsteps;
+
+import com.sinthoras.visualprospecting.VP;
+import com.sinthoras.visualprospecting.integration.model.locations.DirtyChunkLocation;
+import journeymap.client.render.draw.DrawStep;
+import journeymap.client.render.draw.DrawUtil;
+import journeymap.client.render.map.GridRenderer;
+
+import java.awt.geom.Point2D;
+
+public class DirtyChunkDrawStep implements DrawStep {
+
+    private final DirtyChunkLocation dirtyChunkLocation;
+
+    public DirtyChunkDrawStep(DirtyChunkLocation dirtyChunkLocation) {
+        this.dirtyChunkLocation = dirtyChunkLocation;
+    }
+
+    @Override
+    public void draw(double draggedPixelX, double draggedPixelY, GridRenderer gridRenderer, float drawScale, double fontScale, double rotation) {
+        final int zoom = gridRenderer.getZoom();
+        double blockSize = Math.pow(2, zoom);
+        final Point2D.Double blockAsPixel = gridRenderer.getBlockPixelInGrid(dirtyChunkLocation.getBlockX(), dirtyChunkLocation.getBlockZ());
+        final Point2D.Double pixel = new Point2D.Double(blockAsPixel.getX() + draggedPixelX, blockAsPixel.getY() + draggedPixelY);
+        float alpha = 0.5f;
+        alpha *= alpha * 204;
+        int color = dirtyChunkLocation.isDirty() ? 0xFF0000 : 0x00FFAA;
+        DrawUtil.drawRectangle(pixel.getX(), pixel.getY(),
+                VP.chunkWidth * blockSize, VP.chunkDepth * blockSize,
+                color, (int)alpha);
+
+        if(dirtyChunkLocation.isDirty()) {
+            final int borderColor = 0xFFD700;
+            final int borderAlpha = 204;
+            DrawUtil.drawRectangle(pixel.getX(), pixel.getY(), 15 * blockSize, blockSize, borderColor, borderAlpha);
+            DrawUtil.drawRectangle(pixel.getX() + 15 * blockSize, pixel.getY(), blockSize, 15 * blockSize, borderColor, borderAlpha);
+            DrawUtil.drawRectangle(pixel.getX() + 1 * blockSize, pixel.getY() + 15 * blockSize, 15 * blockSize, blockSize, borderColor, borderAlpha);
+            DrawUtil.drawRectangle(pixel.getX(), pixel.getY() + 1 * blockSize, blockSize, 15 * blockSize, borderColor, borderAlpha);
+
+            DrawUtil.drawLabel("D",
+                    pixel.getX() + 13 * blockSize, pixel.getY() + 13 * blockSize,
+                    DrawUtil.HAlign.Left, DrawUtil.VAlign.Above,
+                    0, 180, 0x00FFFFFF, 255, fontScale, false, rotation);
+        }
+    }
+}

--- a/src/main/java/com/sinthoras/visualprospecting/integration/journeymap/render/DirtyChunkRenderer.java
+++ b/src/main/java/com/sinthoras/visualprospecting/integration/journeymap/render/DirtyChunkRenderer.java
@@ -1,0 +1,28 @@
+package com.sinthoras.visualprospecting.integration.journeymap.render;
+
+import com.sinthoras.visualprospecting.integration.journeymap.drawsteps.DirtyChunkDrawStep;
+import com.sinthoras.visualprospecting.integration.model.layers.DirtyChunkLayerManager;
+import com.sinthoras.visualprospecting.integration.model.locations.DirtyChunkLocation;
+import com.sinthoras.visualprospecting.integration.model.locations.ILocationProvider;
+import journeymap.client.render.draw.DrawStep;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class DirtyChunkRenderer extends LayerRenderer {
+
+    public static final DirtyChunkRenderer instance = new DirtyChunkRenderer();
+
+    public DirtyChunkRenderer() {
+        super(DirtyChunkLayerManager.instance);
+    }
+
+    @Override
+    public List<? extends DrawStep> mapLocationProviderToDrawStep(List<? extends ILocationProvider> visibleElements) {
+        final List<DirtyChunkDrawStep> drawSteps = new ArrayList<>();
+        visibleElements.stream()
+                .map(element -> (DirtyChunkLocation) element)
+                .forEach(location -> drawSteps.add(new DirtyChunkDrawStep(location)));
+        return drawSteps;
+    }
+}

--- a/src/main/java/com/sinthoras/visualprospecting/integration/model/MapState.java
+++ b/src/main/java/com/sinthoras/visualprospecting/integration/model/MapState.java
@@ -1,5 +1,6 @@
 package com.sinthoras.visualprospecting.integration.model;
 
+import com.sinthoras.visualprospecting.Config;
 import com.sinthoras.visualprospecting.integration.model.buttons.*;
 import com.sinthoras.visualprospecting.integration.model.layers.*;
 import com.sinthoras.visualprospecting.integration.tcnodetracker.NTNodeTrackerWaypointManager;
@@ -28,5 +29,10 @@ public class MapState {
 
         buttons.add(OreVeinButtonManager.instance);
         layers.add(OreVeinLayerManager.instance);
+
+        if(Config.enableDeveloperOverlays) {
+            buttons.add(DirtyChunkButtonManager.instance);
+            layers.add(DirtyChunkLayerManager.instance);
+        }
     }
 }

--- a/src/main/java/com/sinthoras/visualprospecting/integration/model/buttons/DirtyChunkButtonManager.java
+++ b/src/main/java/com/sinthoras/visualprospecting/integration/model/buttons/DirtyChunkButtonManager.java
@@ -1,0 +1,10 @@
+package com.sinthoras.visualprospecting.integration.model.buttons;
+
+public class DirtyChunkButtonManager extends ButtonManager {
+
+    public static final DirtyChunkButtonManager instance = new DirtyChunkButtonManager();
+
+    public DirtyChunkButtonManager() {
+        super("visualprospecting.button.dirtychunk", "nodes");
+    }
+}

--- a/src/main/java/com/sinthoras/visualprospecting/integration/model/layers/DirtyChunkLayerManager.java
+++ b/src/main/java/com/sinthoras/visualprospecting/integration/model/layers/DirtyChunkLayerManager.java
@@ -1,0 +1,60 @@
+package com.sinthoras.visualprospecting.integration.model.layers;
+
+import com.sinthoras.visualprospecting.Utils;
+import com.sinthoras.visualprospecting.integration.model.buttons.DirtyChunkButtonManager;
+import com.sinthoras.visualprospecting.integration.model.locations.DirtyChunkLocation;
+import com.sinthoras.visualprospecting.integration.model.locations.ILocationProvider;
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.entity.EntityClientPlayerMP;
+import net.minecraft.server.MinecraftServer;
+import net.minecraft.world.World;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class DirtyChunkLayerManager extends LayerManager {
+
+    public static final DirtyChunkLayerManager instance = new DirtyChunkLayerManager();
+
+    public DirtyChunkLayerManager() {
+        super(DirtyChunkButtonManager.instance);
+    }
+
+    @Override
+    protected boolean needsRegenerateVisibleElements(int minBlockX, int minBlockZ, int maxBlockX, int maxBlockZ) {
+        return true;
+    }
+
+    @Override
+    protected List<? extends ILocationProvider> generateVisibleElements(int minBlockX, int minBlockZ, int maxBlockX, int maxBlockZ) {
+        final int minX = Utils.coordBlockToChunk(minBlockX);
+        final int minZ = Utils.coordBlockToChunk(minBlockZ);
+        final int maxX = Utils.coordBlockToChunk(maxBlockX);
+        final int maxZ = Utils.coordBlockToChunk(maxBlockZ);
+        final EntityClientPlayerMP player = Minecraft.getMinecraft().thePlayer;
+        final int playerDimensionId = player.dimension;
+        final int renderDistance = Minecraft.getMinecraft().gameSettings.renderDistanceChunks;
+
+        ArrayList<DirtyChunkLocation> dirtyChunks = new ArrayList<>();
+
+        if (MinecraftServer.getServer() == null || MinecraftServer.getServer().worldServerForDimension(playerDimensionId) == null) {
+            return dirtyChunks;
+        }
+
+        World w = MinecraftServer.getServer().worldServerForDimension(playerDimensionId);
+
+        for (int chunkX = minX; chunkX <= maxX; chunkX++) {
+            for (int chunkZ = minZ; chunkZ <= maxZ; chunkZ++) {
+                int dx = player.chunkCoordX - chunkX;
+                int dz = player.chunkCoordZ - chunkZ;
+                if (dx * dx + dz * dz > renderDistance * renderDistance) {
+                    continue;
+                }
+                final boolean dirty = w.getChunkFromChunkCoords(chunkX, chunkZ).isModified;
+                dirtyChunks.add(new DirtyChunkLocation(chunkX, chunkZ, playerDimensionId, dirty));
+            }
+        }
+
+        return dirtyChunks;
+    }
+}

--- a/src/main/java/com/sinthoras/visualprospecting/integration/model/layers/DirtyChunkLayerManager.java
+++ b/src/main/java/com/sinthoras/visualprospecting/integration/model/layers/DirtyChunkLayerManager.java
@@ -8,6 +8,8 @@ import net.minecraft.client.Minecraft;
 import net.minecraft.client.entity.EntityClientPlayerMP;
 import net.minecraft.server.MinecraftServer;
 import net.minecraft.world.World;
+import net.minecraft.world.chunk.IChunkProvider;
+import net.minecraft.world.gen.ChunkProviderServer;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -33,7 +35,6 @@ public class DirtyChunkLayerManager extends LayerManager {
         final int maxZ = Utils.coordBlockToChunk(maxBlockZ);
         final EntityClientPlayerMP player = Minecraft.getMinecraft().thePlayer;
         final int playerDimensionId = player.dimension;
-        final int renderDistance = Minecraft.getMinecraft().gameSettings.renderDistanceChunks;
 
         ArrayList<DirtyChunkLocation> dirtyChunks = new ArrayList<>();
 
@@ -42,12 +43,11 @@ public class DirtyChunkLayerManager extends LayerManager {
         }
 
         World w = MinecraftServer.getServer().worldServerForDimension(playerDimensionId);
+        IChunkProvider chunkProvider = w.getChunkProvider();
 
         for (int chunkX = minX; chunkX <= maxX; chunkX++) {
             for (int chunkZ = minZ; chunkZ <= maxZ; chunkZ++) {
-                int dx = player.chunkCoordX - chunkX;
-                int dz = player.chunkCoordZ - chunkZ;
-                if (dx * dx + dz * dz > renderDistance * renderDistance) {
+                if (!chunkProvider.chunkExists(chunkX, chunkZ)) {
                     continue;
                 }
                 final boolean dirty = w.getChunkFromChunkCoords(chunkX, chunkZ).isModified;

--- a/src/main/java/com/sinthoras/visualprospecting/integration/model/locations/DirtyChunkLocation.java
+++ b/src/main/java/com/sinthoras/visualprospecting/integration/model/locations/DirtyChunkLocation.java
@@ -1,0 +1,32 @@
+package com.sinthoras.visualprospecting.integration.model.locations;
+
+import com.sinthoras.visualprospecting.Utils;
+
+public class DirtyChunkLocation implements ILocationProvider {
+
+    private final int blockX;
+    private final int blockZ;
+    private final int dimensionId;
+    private final boolean dirty;
+
+    public DirtyChunkLocation(int chunkX, int chunkZ, int dimensionId, boolean dirty) {
+        blockX = Utils.coordChunkToBlock(chunkX);
+        blockZ = Utils.coordChunkToBlock(chunkZ);
+        this.dimensionId = dimensionId;
+        this.dirty = dirty;
+    }
+
+    public double getBlockX() {
+        return blockX + 0.5;
+    }
+
+    public double getBlockZ() {
+        return blockZ + 0.5;
+    }
+
+    public int getDimensionId() {
+        return dimensionId;
+    }
+
+    public boolean isDirty() {return dirty;}
+}

--- a/src/main/resources/assets/visualprospecting/lang/en_US.lang
+++ b/src/main/resources/assets/visualprospecting/lang/en_US.lang
@@ -4,6 +4,7 @@ visualprospecting.veins.prospected=You found %s new ore veins!
 visualprospecting.undergroundfluid.prospected.onlynew=You found %s new oil fields!
 visualprospecting.undergroundfluid.prospected.onlyupdated=You updated %s oil fields!
 visualprospecting.undergroundfluid.prospected.newandupdated=You found %s new and updated %s oil fields!
+visualprospecting.button.dirtychunk=Show Dirty Chunks (Developer, Singleplayer only)
 visualprospecting.button.orevein=Show GT Ore Veins
 visualprospecting.button.undergroundfluid=Show GT Underground Fluids
 visualprospecting.button.nodes=Show TC Nodes


### PR DESCRIPTION
I used this to track down <https://github.com/GTNewHorizons/StorageDrawers/pull/15>, and thought it could be helpful in the future. It's hidden behind a config switch, because it requires singleplayer and is a technical debugging tool rather than something useful in normal gameplay.

![Dirty chunks in JourneyMap developer overlay](https://i.ibb.co/XX1hqS5/2022-03-30-18-06-56.png)