### PR TITLE
Check for null NBT tag in Written Book mixin

### DIFF
--- a/src/main/java/com/sinthoras/visualprospecting/mixins/early/minecraft/ItemEditableBookMixin.java
+++ b/src/main/java/com/sinthoras/visualprospecting/mixins/early/minecraft/ItemEditableBookMixin.java
@@ -31,7 +31,7 @@ public class ItemEditableBookMixin {
             CallbackInfoReturnable<ItemStack> cir) {
         if (!world.isRemote) {
             final NBTTagCompound compound = itemStack.getTagCompound();
-            if (compound.hasKey(Tags.VISUALPROSPECTING_FLAG)) {
+            if (compound != null && compound.hasKey(Tags.VISUALPROSPECTING_FLAG)) {
                 final int dimensionId = compound.getInteger(Tags.PROSPECTION_DIMENSION_ID);
                 final int blockX = compound.getInteger(Tags.PROSPECTION_BLOCK_X);
                 final int blockZ = compound.getInteger(Tags.PROSPECTION_BLOCK_Z);


### PR DESCRIPTION
This fixes the cause of the crash reported in https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/13487
However I'm still unsure why such a book can be produced in the first place.