### PR TITLE
Adjust vp to fixed gt oregen

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -1,7 +1,7 @@
 dependencies {
     shadowImplementation('com.github.GTNewHorizons:Enklume:2.0.0:dev')
 
-    api('com.github.GTNewHorizons:GT5-Unofficial:5.09.43.30:dev')
+    api('com.github.GTNewHorizons:GT5-Unofficial:5.09.43.88-pre:dev')
     api('curse.maven:journeymap-32274:4500659')
 
     devOnlyNonPublishable('com.github.GTNewHorizons:TCNodeTracker:1.1.7:dev')

--- a/src/main/java/com/sinthoras/visualprospecting/Utils.java
+++ b/src/main/java/com/sinthoras/visualprospecting/Utils.java
@@ -20,6 +20,7 @@ import com.google.gson.reflect.TypeToken;
 import com.sinthoras.visualprospecting.hooks.HooksClient;
 
 import cpw.mods.fml.common.Loader;
+import gregtech.common.GT_Worldgenerator;
 
 public class Utils {
 
@@ -75,7 +76,17 @@ public class Utils {
     }
 
     public static int mapToCenterOreChunkCoord(final int chunkCoord) {
-        return chunkCoord - Math.floorMod(chunkCoord, 3) + 1;
+        if (GT_Worldgenerator.useNewOregenPattern) {
+            // new evenly spaced ore pattern
+            return chunkCoord - Math.floorMod(chunkCoord, 3) + 1;
+        } else {
+            // old bugged ore pattern
+            if (chunkCoord >= 0) {
+                return chunkCoord - (chunkCoord % 3) + 1;
+            } else {
+                return chunkCoord - (chunkCoord % 3) - 1;
+            }
+        }
     }
 
     public static int mapToCornerUndergroundFluidChunkCoord(final int chunkCoord) {

--- a/src/main/java/com/sinthoras/visualprospecting/Utils.java
+++ b/src/main/java/com/sinthoras/visualprospecting/Utils.java
@@ -75,11 +75,7 @@ public class Utils {
     }
 
     public static int mapToCenterOreChunkCoord(final int chunkCoord) {
-        if (chunkCoord >= 0) {
-            return chunkCoord - (chunkCoord % 3) + 1;
-        } else {
-            return chunkCoord - (chunkCoord % 3) - 1;
-        }
+        return chunkCoord - Math.floorMod(chunkCoord, 3) + 1;
     }
 
     public static int mapToCornerUndergroundFluidChunkCoord(final int chunkCoord) {

--- a/src/main/java/com/sinthoras/visualprospecting/Utils.java
+++ b/src/main/java/com/sinthoras/visualprospecting/Utils.java
@@ -76,7 +76,7 @@ public class Utils {
     }
 
     public static int mapToCenterOreChunkCoord(final int chunkCoord) {
-        if (GT_Worldgenerator.useNewOregenPattern) {
+        if (GT_Worldgenerator.oregenPattern == GT_Worldgenerator.OregenPattern.EQUAL_SPACING) {
             // new evenly spaced ore pattern
             return chunkCoord - Math.floorMod(chunkCoord, 3) + 1;
         } else {


### PR DESCRIPTION
Depends on https://github.com/GTNewHorizons/GT5-Unofficial/pull/2081 (this is in fact the gt pre dependency in the dependency.gradle)

This lets VP detect automatically which gt oregen pattern is used to scan and show ore veins correctly in both old and new worlds.