### PR TITLE
Actually fix !visualprospectingnearspawn

### DIFF
--- a/src/main/java/com/sinthoras/visualprospecting/database/WorldCache.java
+++ b/src/main/java/com/sinthoras/visualprospecting/database/WorldCache.java
@@ -39,12 +39,16 @@ public abstract class WorldCache {
         final Set<Integer> dimensionsIds = new HashSet<>();
         dimensionsIds.addAll(oreVeinDimensionBuffers.keySet());
         dimensionsIds.addAll(undergroundFluidDimensionBuffers.keySet());
+        dimensionsIds.addAll(dimensions.keySet());
         if (dimensionsIds.isEmpty()) {
             return false;
         }
 
         for (int dimensionId : dimensionsIds) {
-            final DimensionCache dimension = new DimensionCache(dimensionId);
+            DimensionCache dimension = dimensions.get(dimensionId);
+            if (dimension == null) {
+                dimension = new DimensionCache(dimensionId);
+            }
             dimension.loadCache(
                     oreVeinDimensionBuffers.get(dimensionId),
                     undergroundFluidDimensionBuffers.get(dimensionId));


### PR DESCRIPTION
The server cache gets initialized after spawn chunks are generated, and was losing all its data when doing so. Just don't clear any data that already exists in the cache, and the problem goes away.