### PR TITLE
Fix Oregen Pattern Info received to late

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,4 +1,4 @@
-//version: 1685785062
+//version: 1690104383
 /*
  DO NOT CHANGE THIS FILE!
  Also, you may replace this file at any time if there is an update available.
@@ -69,7 +69,7 @@ plugins {
     id 'com.diffplug.spotless' version '6.13.0' apply false // 6.13.0 is the last jvm8 supporting version
     id 'com.modrinth.minotaur' version '2.+' apply false
     id 'com.matthewprenger.cursegradle' version '1.4.0' apply false
-    id 'com.gtnewhorizons.retrofuturagradle' version '1.3.14'
+    id 'com.gtnewhorizons.retrofuturagradle' version '1.3.21'
 }
 
 print("You might want to check out './gradlew :faq' if your build fails.\n")
@@ -115,6 +115,8 @@ propertyDefaultIfUnset("usesMixinDebug", project.usesMixins)
 propertyDefaultIfUnset("forceEnableMixins", false)
 propertyDefaultIfUnset("channel", "stable")
 propertyDefaultIfUnset("mappingsVersion", "12")
+propertyDefaultIfUnset("usesMavenPublishing", true)
+propertyDefaultIfUnset("mavenPublishUrl", "http://jenkins.usrv.eu:8081/nexus/content/repositories/releases")
 propertyDefaultIfUnset("modrinthProjectId", "")
 propertyDefaultIfUnset("modrinthRelations", "")
 propertyDefaultIfUnset("curseForgeProjectId", "")
@@ -357,7 +359,27 @@ catch (Exception ignored) {
 String identifiedVersion
 String versionOverride = System.getenv("VERSION") ?: null
 try {
-    identifiedVersion = versionOverride == null ? gitVersion() : versionOverride
+    // Produce a version based on the tag, or for branches something like 0.2.2-configurable-maven-and-extras.38+43090270b6-dirty
+    if (versionOverride == null) {
+        def gitDetails = versionDetails()
+        def isDirty = gitVersion().endsWith(".dirty") // No public API for this, isCleanTag has a different meaning
+        String branchName = gitDetails.branchName ?: (System.getenv('GIT_BRANCH') ?: 'git')
+        if (branchName.startsWith('origin/')) {
+            branchName = branchName.minus('origin/')
+        }
+        branchName = branchName.replaceAll("[^a-zA-Z0-9-]+", "-") // sanitize branch names for semver
+        identifiedVersion = gitDetails.lastTag ?: '${gitDetails.gitHash}'
+        if (gitDetails.commitDistance > 0) {
+            identifiedVersion += "-${branchName}.${gitDetails.commitDistance}+${gitDetails.gitHash}"
+            if (isDirty) {
+                identifiedVersion += "-dirty"
+            }
+        } else if (isDirty) {
+            identifiedVersion += "-${branchName}+${gitDetails.gitHash}-dirty"
+        }
+    } else {
+        identifiedVersion = versionOverride
+    }
 }
 catch (Exception ignored) {
     out.style(Style.Failure).text(
@@ -465,8 +487,17 @@ sourceSets {
     }
 }
 
-if (file('addon.gradle').exists()) {
+if (file('addon.gradle.kts').exists()) {
+    apply from: 'addon.gradle.kts'
+} else if (file('addon.gradle').exists()) {
     apply from: 'addon.gradle'
+}
+
+// File for local tweaks not commited to Git
+if (file('addon.local.gradle.kts').exists()) {
+    apply from: 'addon.local.gradle.kts'
+} else if (file('addon.local.gradle').exists()) {
+    apply from: 'addon.local.gradle'
 }
 
 // Allow unsafe repos but warn
@@ -479,7 +510,14 @@ repositories.configureEach { repo ->
     }
 }
 
-apply from: 'repositories.gradle'
+if (file('repositories.gradle.kts').exists()) {
+    apply from: 'repositories.gradle.kts'
+} else if (file('repositories.gradle').exists()) {
+    apply from: 'repositories.gradle'
+} else {
+    logger.error("Neither repositories.gradle.kts nor repositories.gradle was found, make sure you extracted the full ExampleMod template.")
+    throw new RuntimeException("Missing repositories.gradle[.kts]")
+}
 
 configurations {
     runtimeClasspath.extendsFrom(runtimeOnlyNonPublishable)
@@ -537,11 +575,26 @@ repositories {
         }
     }
     if (includeWellKnownRepositories.toBoolean()) {
-        maven {
-            name "CurseMaven"
-            url "https://cursemaven.com"
-            content {
+        exclusiveContent {
+            forRepository {
+                maven {
+                    name "CurseMaven"
+                    url "https://cursemaven.com"
+                }
+            }
+            filter {
                 includeGroup "curse.maven"
+            }
+        }
+        exclusiveContent {
+            forRepository {
+                maven {
+                    name = "Modrinth"
+                    url = "https://api.modrinth.com/maven"
+                }
+            }
+            filter {
+                includeGroup "maven.modrinth"
             }
         }
         maven {
@@ -585,7 +638,7 @@ dependencies {
         }
     }
     if (usesMixins.toBoolean()) {
-        implementation(mixinProviderSpec)
+        implementation(modUtils.enableMixins(mixinProviderSpec))
     } else if (forceEnableMixins.toBoolean()) {
         runtimeOnlyNonPublishable(mixinProviderSpec)
     }
@@ -611,12 +664,34 @@ configurations.all {
     }
 }
 
-apply from: 'dependencies.gradle'
+dependencies {
+    constraints {
+        def minGtnhLibVersion = "0.0.13"
+        implementation("com.github.GTNewHorizons:GTNHLib:${minGtnhLibVersion}") {
+            because("fixes duplicate mod errors in java 17 configurations using old gtnhlib")
+        }
+        runtimeOnly("com.github.GTNewHorizons:GTNHLib:${minGtnhLibVersion}") {
+            because("fixes duplicate mod errors in java 17 configurations using old gtnhlib")
+        }
+        devOnlyNonPublishable("com.github.GTNewHorizons:GTNHLib:${minGtnhLibVersion}") {
+            because("fixes duplicate mod errors in java 17 configurations using old gtnhlib")
+        }
+        runtimeOnlyNonPublishable("com.github.GTNewHorizons:GTNHLib:${minGtnhLibVersion}") {
+            because("fixes duplicate mod errors in java 17 configurations using old gtnhlib")
+        }
+    }
+}
+
+if (file('dependencies.gradle.kts').exists()) {
+    apply from: 'dependencies.gradle.kts'
+} else if (file('dependencies.gradle').exists()) {
+    apply from: 'dependencies.gradle'
+} else {
+    logger.error("Neither dependencies.gradle.kts nor dependencies.gradle was found, make sure you extracted the full ExampleMod template.")
+    throw new RuntimeException("Missing dependencies.gradle[.kts]")
+}
 
 def mixingConfigRefMap = 'mixins.' + modId + '.refmap.json'
-def mixinTmpDir = buildDir.path + File.separator + 'tmp' + File.separator + 'mixins'
-def refMap = "${mixinTmpDir}" + File.separator + mixingConfigRefMap
-def mixinSrg = "${mixinTmpDir}" + File.separator + "mixins.srg"
 
 tasks.register('generateAssets') {
     group = "GTNH Buildscript"
@@ -648,46 +723,17 @@ tasks.register('generateAssets') {
 }
 
 if (usesMixins.toBoolean()) {
-    tasks.named("reobfJar", ReobfuscatedJar).configure {
-        extraSrgFiles.from(mixinSrg)
-    }
-
     tasks.named("processResources").configure {
         dependsOn("generateAssets")
     }
 
     tasks.named("compileJava", JavaCompile).configure {
-        doFirst {
-            new File(mixinTmpDir).mkdirs()
-        }
         options.compilerArgs += [
-            "-AreobfSrgFile=${tasks.reobfJar.srg.get().asFile}",
-            "-AoutSrgFile=${mixinSrg}",
-            "-AoutRefMapFile=${refMap}",
             // Elan: from what I understand they are just some linter configs so you get some warning on how to properly code
             "-XDenableSunApiLintControl",
             "-XDignore.symbol.file"
         ]
     }
-
-    pluginManager.withPlugin('org.jetbrains.kotlin.kapt') {
-        kapt {
-            correctErrorTypes = true
-            javacOptions {
-                option("-AreobfSrgFile=${tasks.reobfJar.srg.get().asFile}")
-                option("-AoutSrgFile=$mixinSrg")
-                option("-AoutRefMapFile=$refMap")
-            }
-        }
-        tasks.configureEach { task ->
-            if (task.name == "kaptKotlin") {
-                task.doFirst {
-                    new File(mixinTmpDir).mkdirs()
-                }
-            }
-        }
-    }
-
 }
 
 tasks.named("processResources", ProcessResources).configure {
@@ -705,7 +751,6 @@ tasks.named("processResources", ProcessResources).configure {
     }
 
     if (usesMixins.toBoolean()) {
-        from refMap
         dependsOn("compileJava", "compileScala")
     }
 }
@@ -724,13 +769,13 @@ ext.java17PatchDependenciesCfg = configurations.create("java17PatchDependencies"
 }
 
 dependencies {
-    def lwjgl3ifyVersion = '1.3.5'
+    def lwjgl3ifyVersion = '1.4.0'
     def asmVersion = '9.4'
     if (modId != 'lwjgl3ify') {
         java17Dependencies("com.github.GTNewHorizons:lwjgl3ify:${lwjgl3ifyVersion}")
     }
     if (modId != 'hodgepodge') {
-        java17Dependencies('com.github.GTNewHorizons:Hodgepodge:2.2.13')
+        java17Dependencies('com.github.GTNewHorizons:Hodgepodge:2.2.19')
     }
 
     java17PatchDependencies('net.minecraft:launchwrapper:1.15') {transitive = false}
@@ -979,6 +1024,9 @@ idea {
                 }
             }
             runConfigurations {
+                "0. Build and Test"(Gradle) {
+                    taskNames = ["build"]
+                }
                 "1. Run Client"(Gradle) {
                     taskNames = ["runClient"]
                 }
@@ -1098,6 +1146,11 @@ tasks.named("processIdeaSettings").configure {
     dependsOn("injectTags")
 }
 
+tasks.named("ideVirtualMainClasses").configure {
+    // Make IntelliJ "Build project" build the mod jars
+    dependsOn("jar", "reobfJar", "spotlessCheck")
+}
+
 // workaround variable hiding in pom processing
 def projectConfigs = project.configurations
 
@@ -1118,12 +1171,14 @@ publishing {
     }
 
     repositories {
-        maven {
-            url = "http://jenkins.usrv.eu:8081/nexus/content/repositories/releases"
-            allowInsecureProtocol = true
-            credentials {
-                username = System.getenv("MAVEN_USER") ?: "NONE"
-                password = System.getenv("MAVEN_PASSWORD") ?: "NONE"
+        if (usesMavenPublishing.toBoolean()) {
+            maven {
+                url = mavenPublishUrl
+                allowInsecureProtocol = mavenPublishUrl.startsWith("http://") // Mostly for the GTNH maven
+                credentials {
+                    username = System.getenv("MAVEN_USER") ?: "NONE"
+                    password = System.getenv("MAVEN_PASSWORD") ?: "NONE"
+                }
             }
         }
     }
@@ -1238,7 +1293,7 @@ def addCurseForgeRelation(String type, String name) {
 
 // Updating
 
-def buildscriptGradleVersion = "8.1.1"
+def buildscriptGradleVersion = "8.2.1"
 
 tasks.named('wrapper', Wrapper).configure {
     gradleVersion = buildscriptGradleVersion
@@ -1344,8 +1399,14 @@ boolean isNewBuildScriptVersionAvailable() {
 
     String currentBuildScript = getFile("build.gradle").getText()
     String currentBuildScriptHash = getVersionHash(currentBuildScript)
-    String availableBuildScript = availableBuildScriptUrl().newInputStream(parameters).getText()
-    String availableBuildScriptHash = getVersionHash(availableBuildScript)
+    String availableBuildScriptHash
+    try {
+        String availableBuildScript = availableBuildScriptUrl().newInputStream(parameters).getText()
+        availableBuildScriptHash = getVersionHash(availableBuildScript)
+    } catch (IOException e) {
+        logger.warn("Could not check for buildscript update availability: {}", e.message)
+        return false
+    }
 
     boolean isUpToDate = currentBuildScriptHash.empty || availableBuildScriptHash.empty || currentBuildScriptHash == availableBuildScriptHash
     return !isUpToDate
@@ -1509,4 +1570,18 @@ def getSecondaryArtifacts() {
     if (!noPublishedSources) secondaryArtifacts += [sourcesJar]
     if (apiPackage) secondaryArtifacts += [apiJar]
     return secondaryArtifacts
+}
+
+// For easier scripting of things that require variables defined earlier in the buildscript
+if (file('addon.late.gradle.kts').exists()) {
+    apply from: 'addon.late.gradle.kts'
+} else if (file('addon.late.gradle').exists()) {
+    apply from: 'addon.late.gradle'
+}
+
+// File for local tweaks not commited to Git
+if (file('addon.late.local.gradle.kts').exists()) {
+    apply from: 'addon.late.local.gradle.kts'
+} else if (file('addon.late.local.gradle').exists()) {
+    apply from: 'addon.late.local.gradle'
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -15,22 +15,40 @@ autoUpdateBuildScript = false
 minecraftVersion = 1.7.10
 forgeVersion = 10.13.4.1614
 
+# Specify a MCP channel and mappings version for dependency deobfuscation and the deobfParams task.
+channel = stable
+mappingsVersion = 12
+
+# Define other MCP mappings for dependency deobfuscation
+remoteMappings = https://raw.githubusercontent.com/MinecraftForge/FML/1.7.10/conf/
+
 # Select a username for testing your mod with breakpoints. You may leave this empty for a random username each time you
 # restart Minecraft in development. Choose this dependent on your mod:
 # Do you need consistent player progressing (for example Thaumcraft)? -> Select a name
 # Do you need to test how your custom blocks interacts with a player that is not the owner? -> leave name empty
 developmentEnvironmentUserName = Developer
 
-# Define a source file of your project with:
+# Enables using modern java syntax (up to version 17) via Jabel, while still targeting JVM 8.
+# See https://github.com/bsideup/jabel for details on how this works.
+enableModernJavaSyntax = true
+
+# Enables injecting missing generics into the decompiled source code for a better coding experience
+# Turns most publicly visible List, Map, etc. into proper List<Type>, Map<K, V> types
+enableGenericInjection = true
+
+# Generate a class with String fields for the mod id, name, version and group name named with the fields below
+generateGradleTokenClass = com.sinthoras.visualprospecting.Version
+gradleTokenModId =
+gradleTokenModName =
+gradleTokenVersion = VERSION
+gradleTokenGroupName =
+# [DEPRECATED]
+# Multiple source files can be defined here by providing a comma-seperated list: Class1.java,Class2.java,Class3.java
 # public static final String VERSION = "GRADLETOKEN_VERSION";
 # The string's content will be replaced with your mod's version when compiled. You should use this to specify your mod's
 # version in @Mod([...], version = VERSION, [...])
 # Leave these properties empty to skip individual token replacements
-replaceGradleTokenInFile = Tags.java
-gradleTokenModId = GRADLETOKEN_MODID
-gradleTokenModName = GRADLETOKEN_MODNAME
-gradleTokenVersion = GRADLETOKEN_VERSION
-gradleTokenGroupName = GRADLETOKEN_GROUPNAME
+replaceGradleTokenInFile =
 
 # In case your mod provides an API for other mods to implement you may declare its package here. Otherwise, you can
 # leave this property empty.
@@ -38,11 +56,14 @@ gradleTokenGroupName = GRADLETOKEN_GROUPNAME
 apiPackage =
 
 # Specify the configuration file for Forge's access transformers here. It must be placed into /src/main/resources/META-INF/
-# Example value: mymodid_at.cfg
+# There can be multiple files in a comma-separated list.
+# Example value: mymodid_at.cfg,nei_at.cfg
 accessTransformersFile =
 
 # Provides setup for Mixins if enabled. If you don't know what mixins are: Keep it disabled!
 usesMixins = true
+# Adds some debug arguments like verbose output and export
+usesMixinDebug = true
 # Specify the location of your implementation of IMixinConfigPlugin. Leave it empty otherwise.
 mixinPlugin =
 # Specify the package that contains all of your Mixins. You may only place Mixins in this package or the build will fail!
@@ -55,10 +76,74 @@ coreModClass = mixinplugin.VisualProspectingEarlyMixinLoader
 # that is annotated with @Mod) you want this to be true. When in doubt: leave it on false!
 containsMixinsAndOrCoreModOnly = false
 
-# If enabled, you may use 'shadowImplementation' for dependencies. They will be integrated in your jar. It is your
+# Enables Mixins even if this mod doesn't use them, useful if one of the dependencies uses mixins.
+forceEnableMixins = false
+
+# If enabled, you may use 'shadowCompile' for dependencies. They will be integrated in your jar. It is your
 # responsibility check the licence and request permission for distribution, if required.
 usesShadowedDependencies = true
+# If disabled, won't remove unused classes from shaded dependencies. Some libraries use reflection to access
+# their own classes, making the minimization unreliable.
+minimizeShadowedDependencies = true
+# If disabled, won't rename the shadowed classes.
+relocateShadowedDependencies = true
+
+# Adds the GTNH maven, CurseMaven, IC2/Player maven, and some more well-known 1.7.10 repositories
+includeWellKnownRepositories = true
+
+# Change these to your Maven coordinates if you want to publish to a custom Maven repository instead of the default GTNH Maven.
+# Authenticate with the MAVEN_USERNAME and MAVEN_PASSWORD environment variables.
+# If you need a more complex setup disable maven publishing here and add a publishing repository to addon.gradle.
+usesMavenPublishing = true
+# mavenPublishUrl = http://jenkins.usrv.eu:8081/nexus/content/repositories/releases
+
+# Publishing to modrinth requires you to set the MODRINTH_TOKEN environment variable to your current modrinth API token.
+
+# The project's ID on Modrinth. Can be either the slug or the ID.
+# Leave this empty if you don't want to publish on Modrinth.
+modrinthProjectId =
+
+# The project's relations on Modrinth. You can use this to refer to other projects on Modrinth.
+# Syntax: scope1-type1:name1;scope2-type2:name2;...
+# Where scope can be one of [required, optional, incompatible, embedded],
+#       type can be one of [project, version],
+#       and the name is the Modrinth project or version slug/id of the other mod.
+# Example: required-project:fplib;optional-project:gasstation;incompatible-project:gregtech
+# Note: GTNH Mixins is automatically set as a required dependency if usesMixins = true
+modrinthRelations =
+
+
+# Publishing to CurseForge requires you to set the CURSEFORGE_TOKEN environment variable to one of your CurseForge API tokens.
+
+# The project's numeric ID on CurseForge. You can find this in the About Project box.
+# Leave this empty if you don't want to publish on CurseForge.
+curseForgeProjectId =
+
+# The project's relations on CurseForge. You can use this to refer to other projects on CurseForge.
+# Syntax: type1:name1;type2:name2;...
+# Where type can be one of [requiredDependency, embeddedLibrary, optionalDependency, tool, incompatible],
+#       and the name is the CurseForge project slug of the other mod.
+# Example: requiredDependency:railcraft;embeddedLibrary:cofhlib;incompatible:buildcraft
+# Note: GTNH Mixins is automatically set as a required dependency if usesMixins = true
+curseForgeRelations =
+
 
 # Optional parameter to customize the produced artifacts. Use this to preserver artifact naming when migrating older
 # projects. New projects should not use this parameter.
-#customArchiveBaseName =
+# customArchiveBaseName =
+
+# Optional parameter to prevent the source code from being published
+# noPublishedSources =
+
+# Uncomment this to disable spotless checks
+# This should only be uncommented to keep it easier to sync with upstream/other forks.
+# That is, if there is no other active fork/upstream, NEVER change this.
+# disableSpotless = true
+
+# Override the IDEA build type. Valid value is "" (leave blank, do not override), "idea" (force use native IDEA build), "gradle"
+# (force use delegated build).
+# This is meant to be set in $HOME/.gradle/gradle.properties.
+# e.g. add "systemProp.org.gradle.project.ideaOverrideBuildType=idea" will override the build type to be always native build.
+# WARNING: If you do use this option, it will overwrite whatever you have in your existing projects. This might not be what you want!
+# Usually there is no need to uncomment this here as other developers do not necessarily use the same build type as you.
+# ideaOverrideBuildType = idea

--- a/src/main/java/com/sinthoras/visualprospecting/ServerTranslations.java
+++ b/src/main/java/com/sinthoras/visualprospecting/ServerTranslations.java
@@ -9,6 +9,7 @@ import com.sinthoras.visualprospecting.database.veintypes.VeinType;
 // Backup translations for server side lookups only
 public class ServerTranslations {
 
+    @SuppressWarnings("deprecation")
     public static String getEnglishLocalization(Fluid fluid) {
         if (MinecraftServer.getServer().isSinglePlayer()) {
             return fluid.getLocalizedName();

--- a/src/main/java/com/sinthoras/visualprospecting/Tags.java
+++ b/src/main/java/com/sinthoras/visualprospecting/Tags.java
@@ -5,10 +5,10 @@ package com.sinthoras.visualprospecting;
 public class Tags {
 
     // GRADLETOKEN_* will be replaced by your configuration values at build time
-    public static final String MODID = "GRADLETOKEN_MODID";
-    public static final String MODNAME = "GRADLETOKEN_MODNAME";
-    public static final String VERSION = "GRADLETOKEN_VERSION";
-    public static final String GROUPNAME = "GRADLETOKEN_GROUPNAME";
+    public static final String MODID = "visualprospecting";
+    public static final String MODNAME = "VisualProspecting";
+    public static final String VERSION = Version.VERSION;
+    public static final String GROUPNAME = "com.sinthoras.visualprospecting";
 
     public static final String VISUALPROSPECTING_DIR = MODID + "/";
     public static final String CLIENT_DIR = VISUALPROSPECTING_DIR + "client/";

--- a/src/main/java/com/sinthoras/visualprospecting/database/cachebuilder/DetailedChunkAnalysis.java
+++ b/src/main/java/com/sinthoras/visualprospecting/database/cachebuilder/DetailedChunkAnalysis.java
@@ -19,6 +19,7 @@ public class DetailedChunkAnalysis {
     public final int chunkX;
     public final int chunkZ;
     // For each height we count how often a ore (short) has occured
+    @SuppressWarnings("unchecked")
     private final Map<Short, Integer>[] oresPerY = new HashMap[VP.minecraftWorldHeight];
 
     public DetailedChunkAnalysis(int dimensionId, int chunkX, int chunkZ) {

--- a/src/main/java/com/sinthoras/visualprospecting/hooks/HooksEventBus.java
+++ b/src/main/java/com/sinthoras/visualprospecting/hooks/HooksEventBus.java
@@ -1,16 +1,10 @@
 package com.sinthoras.visualprospecting.hooks;
 
-import net.minecraft.entity.player.EntityPlayer;
-import net.minecraft.entity.player.EntityPlayerMP;
-import net.minecraftforge.event.entity.EntityJoinWorldEvent;
 import net.minecraftforge.event.world.WorldEvent;
 
 import com.sinthoras.visualprospecting.Utils;
-import com.sinthoras.visualprospecting.VP;
 import com.sinthoras.visualprospecting.database.ClientCache;
 import com.sinthoras.visualprospecting.database.ServerCache;
-import com.sinthoras.visualprospecting.database.WorldIdHandler;
-import com.sinthoras.visualprospecting.network.WorldIdNotification;
 
 import cpw.mods.fml.common.eventhandler.SubscribeEvent;
 
@@ -26,16 +20,5 @@ public class HooksEventBus {
     @SubscribeEvent
     public void onEvent(WorldEvent.Save event) {
         ServerCache.instance.saveVeinCache();
-    }
-
-    @SubscribeEvent
-    public void onEvent(EntityJoinWorldEvent event) {
-        if (event.world.isRemote == false) {
-            if (event.entity instanceof EntityPlayerMP) {
-                VP.network.sendTo(new WorldIdNotification(WorldIdHandler.getWorldId()), (EntityPlayerMP) event.entity);
-            } else if (event.entity instanceof EntityPlayer) {
-                ClientCache.instance.loadVeinCache(WorldIdHandler.getWorldId());
-            }
-        }
     }
 }

--- a/src/main/java/com/sinthoras/visualprospecting/hooks/HooksFML.java
+++ b/src/main/java/com/sinthoras/visualprospecting/hooks/HooksFML.java
@@ -1,9 +1,17 @@
 package com.sinthoras.visualprospecting.hooks;
 
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.entity.player.EntityPlayerMP;
+
+import com.sinthoras.visualprospecting.VP;
 import com.sinthoras.visualprospecting.database.ClientCache;
+import com.sinthoras.visualprospecting.database.WorldIdHandler;
+import com.sinthoras.visualprospecting.network.WorldIdNotification;
 import com.sinthoras.visualprospecting.task.TaskManager;
 
+import cpw.mods.fml.common.eventhandler.EventPriority;
 import cpw.mods.fml.common.eventhandler.SubscribeEvent;
+import cpw.mods.fml.common.gameevent.PlayerEvent;
 import cpw.mods.fml.common.gameevent.TickEvent;
 import cpw.mods.fml.common.network.FMLNetworkEvent;
 
@@ -17,5 +25,14 @@ public class HooksFML {
     @SubscribeEvent
     public void onEvent(TickEvent event) {
         TaskManager.instance.onTick();
+    }
+
+    @SubscribeEvent(priority = EventPriority.LOW)
+    public void onEvent(PlayerEvent.PlayerLoggedInEvent event) {
+        if (event.player instanceof EntityPlayerMP playerMP) {
+            VP.network.sendTo(new WorldIdNotification(WorldIdHandler.getWorldId()), playerMP);
+        } else if (event.player instanceof EntityPlayer) {
+            ClientCache.instance.loadVeinCache(WorldIdHandler.getWorldId());
+        }
     }
 }

--- a/src/main/java/com/sinthoras/visualprospecting/integration/journeymap/drawsteps/UndergroundFluidDrawStep.java
+++ b/src/main/java/com/sinthoras/visualprospecting/integration/journeymap/drawsteps/UndergroundFluidDrawStep.java
@@ -60,6 +60,7 @@ public class UndergroundFluidDrawStep implements DrawStep {
                     borderColor,
                     borderAlpha);
 
+            @SuppressWarnings("deprecation")
             final String label = undergroundFluidLocation.getMinProduction() + "L - "
                     + maxAmountInField
                     + "L  "

--- a/src/main/java/com/sinthoras/visualprospecting/integration/model/layers/LayerManager.java
+++ b/src/main/java/com/sinthoras/visualprospecting/integration/model/layers/LayerManager.java
@@ -14,7 +14,6 @@ public abstract class LayerManager {
 
     private final ButtonManager buttonManager;
 
-    private boolean isLayerActive = false;
     protected boolean forceRefresh = false;
     private List<? extends ILocationProvider> visibleElements = new ArrayList<>();
     protected Map<SupportedMods, LayerRenderer> layerRenderer = new EnumMap<>(SupportedMods.class);

--- a/src/main/java/com/sinthoras/visualprospecting/integration/voxelmap/VoxelMapEventHandler.java
+++ b/src/main/java/com/sinthoras/visualprospecting/integration/voxelmap/VoxelMapEventHandler.java
@@ -48,6 +48,7 @@ public class VoxelMapEventHandler {
                         dim)); // dimension
     }
 
+    @SuppressWarnings("deprecation")
     @SubscribeEvent
     public void onFluidProspected(ProspectingNotificationEvent.UndergroundFluid event) {
         if (event.isCanceled()) {

--- a/src/main/java/com/sinthoras/visualprospecting/integration/xaeroworldmap/rendersteps/UndergroundFluidRenderStep.java
+++ b/src/main/java/com/sinthoras/visualprospecting/integration/xaeroworldmap/rendersteps/UndergroundFluidRenderStep.java
@@ -40,6 +40,7 @@ public class UndergroundFluidRenderStep implements RenderStep {
             // min scale that journeymap can go to
             if (scale >= 1 && gui != null) {
                 GL11.glScaled(1 / scale, 1 / scale, 1);
+                @SuppressWarnings("deprecation")
                 final String label = undergroundFluidLocation.getMinProduction() + "L - "
                         + maxAmountInField
                         + "L  "

--- a/src/main/java/com/sinthoras/visualprospecting/item/ProspectorsLog.java
+++ b/src/main/java/com/sinthoras/visualprospecting/item/ProspectorsLog.java
@@ -86,7 +86,7 @@ public class ProspectorsLog extends Item {
     }
 
     @Override
-    public void addInformation(ItemStack item, EntityPlayer player, List infoList, boolean ignored) {
+    public void addInformation(ItemStack item, EntityPlayer player, List<String> infoList, boolean ignored) {
         if (isFilledLog(item)) {
             final NBTTagCompound compound = item.getTagCompound();
             infoList.add(


### PR DESCRIPTION
Fixes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/14081

The packet with the oregen pattern used by the server i sent by GT on `PlayerEvent$PlayerLoggedInEvent`. However, VP builds the client cache on `EntityJoinWorldEvent`, which is fired earlier. Thus, VP only has GT's default to work with, unless the player disconnects and then reconnects to the same server. This PR delays the client caching by also using `PlayerEvent$PlayerLoggedInEvent` but with low priority.

BS update and a small cleanup included for free.