### PR TITLE
ServerUtilities integration allowing for members of a ForgeTeam to have their data synced

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -13,6 +13,8 @@ dependencies {
     compileOnly(deobf('https://media.forgecdn.net/files/4127/328/XaerosWorldMap_1.14.1.22_Forge_1.7.10.jar'))
     compileOnly(deobf('https://media.forgecdn.net/files/2462/146/mod_voxelMap_1.7.0b_for_1.7.10.litemod', 'mod_voxelMap_1.7.0b_for_1.7.10.jar'))
 
+    compileOnly('com.github.GTNewHorizons:ServerUtilities:2.0.2')
+
     // For debugging
     runtimeOnlyNonPublishable('com.github.GTNewHorizons:DetravScannerMod:1.7.2:dev')
 }

--- a/src/main/java/com/sinthoras/visualprospecting/Utils.java
+++ b/src/main/java/com/sinthoras/visualprospecting/Utils.java
@@ -68,6 +68,10 @@ public class Utils {
         }
     }
 
+    public static boolean isServerUtilitiesInstalled() {
+        return Loader.isModLoaded("ServerUtilities");
+    }
+
     public static int coordBlockToChunk(int blockCoord) {
         return blockCoord < 0 ? -((-blockCoord - 1) >> 4) - 1 : blockCoord >> 4;
     }

--- a/src/main/java/com/sinthoras/visualprospecting/hooks/HooksShared.java
+++ b/src/main/java/com/sinthoras/visualprospecting/hooks/HooksShared.java
@@ -3,6 +3,7 @@ package com.sinthoras.visualprospecting.hooks;
 import java.io.IOException;
 import java.util.zip.DataFormatException;
 
+import com.sinthoras.visualprospecting.integration.serverutilities.SUIntegration;
 import net.minecraft.init.Items;
 import net.minecraft.item.ItemStack;
 import net.minecraft.server.MinecraftServer;
@@ -81,6 +82,8 @@ public class HooksShared {
     public void fmlLifeCycleEvent(FMLInitializationEvent event) {
         MinecraftForge.EVENT_BUS.register(new HooksEventBus());
         FMLCommonHandler.instance().bus().register(new HooksFML());
+
+        SUIntegration.proxy.init(event);
     }
 
     // postInit "Handle interaction with other mods, complete your setup based on this."

--- a/src/main/java/com/sinthoras/visualprospecting/integration/serverutilities/SUEventBus.java
+++ b/src/main/java/com/sinthoras/visualprospecting/integration/serverutilities/SUEventBus.java
@@ -1,0 +1,4 @@
+package com.sinthoras.visualprospecting.integration.serverutilities;
+
+public class SUEventBus {
+}

--- a/src/main/java/com/sinthoras/visualprospecting/integration/serverutilities/SUIntegration.java
+++ b/src/main/java/com/sinthoras/visualprospecting/integration/serverutilities/SUIntegration.java
@@ -1,0 +1,18 @@
+package com.sinthoras.visualprospecting.integration.serverutilities;
+
+import com.sinthoras.visualprospecting.Utils;
+import com.sinthoras.visualprospecting.integration.serverutilities.proxy.SUProxyCommon;
+import com.sinthoras.visualprospecting.integration.serverutilities.proxy.SUProxyBase;
+import cpw.mods.fml.common.event.FMLInitializationEvent;
+
+public class SUIntegration {
+    public static final SUProxyBase proxy = createProxy();
+
+    private static SUProxyBase createProxy() {
+        if (Utils.isServerUtilitiesInstalled()) {
+            return new SUProxyCommon();
+        } else {
+            return new SUProxyBase();
+        }
+    }
+}

--- a/src/main/java/com/sinthoras/visualprospecting/integration/serverutilities/proxy/SUProxyBase.java
+++ b/src/main/java/com/sinthoras/visualprospecting/integration/serverutilities/proxy/SUProxyBase.java
@@ -1,0 +1,8 @@
+package com.sinthoras.visualprospecting.integration.serverutilities.proxy;
+
+import cpw.mods.fml.common.event.FMLInitializationEvent;
+
+public class SUProxyBase {
+
+    public void init(FMLInitializationEvent event) { }
+}

--- a/src/main/java/com/sinthoras/visualprospecting/integration/serverutilities/proxy/SUProxyCommon.java
+++ b/src/main/java/com/sinthoras/visualprospecting/integration/serverutilities/proxy/SUProxyCommon.java
@@ -1,0 +1,12 @@
+package com.sinthoras.visualprospecting.integration.serverutilities.proxy;
+
+import com.sinthoras.visualprospecting.integration.serverutilities.SUEventBus;
+import cpw.mods.fml.common.event.FMLInitializationEvent;
+import net.minecraftforge.common.MinecraftForge;
+
+public class SUProxyCommon extends SUProxyBase {
+    @Override
+    public void init(FMLInitializationEvent event) {
+        MinecraftForge.EVENT_BUS.register(new SUEventBus());
+    }
+}


### PR DESCRIPTION
Porting the functionality from my mod that implements this here: https://github.com/Rune580/SharedProspecting
Features include:
- A new Cache for ForgeTeams, functionally similar to the ClientCache but stored on the server.
- Members of a ForgeTeam have their ClientCache synced to the server's TeamCache.
- A full re-sync occurs upon player login.
- Newly discovered ores are synced between online members.