### PR TITLE
Networking Refactor

### DIFF
--- a/src/main/java/com/sinthoras/visualprospecting/database/OreVeinPosition.java
+++ b/src/main/java/com/sinthoras/visualprospecting/database/OreVeinPosition.java
@@ -2,11 +2,10 @@ package com.sinthoras.visualprospecting.database;
 
 import com.sinthoras.visualprospecting.Utils;
 import com.sinthoras.visualprospecting.database.veintypes.VeinType;
-import com.sinthoras.visualprospecting.database.veintypes.VeinTypeCaching;
 
 public class OreVeinPosition {
 
-    private static final int MAX_BYTES = 3 * Integer.BYTES + Byte.BYTES;
+    public static final int MAX_BYTES = 3 * Integer.BYTES + Short.BYTES;
 
     public final int dimensionId;
     public final int chunkX;
@@ -51,7 +50,8 @@ public class OreVeinPosition {
         return this;
     }
 
+    // Leaving this here for compatability sake
     public static int getMaxBytes() {
-        return MAX_BYTES + VeinTypeCaching.getLongesOreNameLength();
+        return MAX_BYTES;
     }
 }

--- a/src/main/java/com/sinthoras/visualprospecting/database/TransferCache.java
+++ b/src/main/java/com/sinthoras/visualprospecting/database/TransferCache.java
@@ -23,10 +23,7 @@ public class TransferCache {
         sharedUndergroundFluids.remove(uuid);
         timestamp.remove(uuid);
 
-        final int oreVeinPositionSizeInRam = OreVeinPosition.getMaxBytes() + 3 * Byte.BYTES; // JVM represents
-                                                                                             // everything aligned at 4
-                                                                                             // bytes
-        final int newEntryBytes = oreVeins.size() * oreVeinPositionSizeInRam
+        final int newEntryBytes = oreVeins.size() * OreVeinPosition.MAX_BYTES
                 + undergroundFluids.size() * UndergroundFluidPosition.BYTES;
 
         while (getUsedMemory() > (Config.maxTransferCacheSizeMB << 20) - newEntryBytes
@@ -54,10 +51,7 @@ public class TransferCache {
     }
 
     private int getUsedMemory() {
-        final int oreVeinPositionSizeInRam = OreVeinPosition.getMaxBytes() + 3 * Byte.BYTES; // JVM represents
-                                                                                             // everything aligned at 4
-                                                                                             // bytes
-        return sharedOreVeins.values().stream().mapToInt(oreVeins -> oreVeins.size() * oreVeinPositionSizeInRam).sum()
+        return sharedOreVeins.values().stream().mapToInt(oreVeins -> oreVeins.size() * OreVeinPosition.MAX_BYTES).sum()
                 + sharedUndergroundFluids.values().stream()
                         .mapToInt(undergroundFluids -> undergroundFluids.size() * UndergroundFluidPosition.BYTES).sum();
     }

--- a/src/main/java/com/sinthoras/visualprospecting/network/ProspectingNotification.java
+++ b/src/main/java/com/sinthoras/visualprospecting/network/ProspectingNotification.java
@@ -1,23 +1,17 @@
 package com.sinthoras.visualprospecting.network;
 
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
-
-import net.minecraftforge.fluids.Fluid;
-import net.minecraftforge.fluids.FluidRegistry;
-
-import com.sinthoras.visualprospecting.VP;
 import com.sinthoras.visualprospecting.database.ClientCache;
 import com.sinthoras.visualprospecting.database.OreVeinPosition;
 import com.sinthoras.visualprospecting.database.UndergroundFluidPosition;
-import com.sinthoras.visualprospecting.database.veintypes.VeinTypeCaching;
-
-import cpw.mods.fml.common.network.ByteBufUtils;
+import com.sinthoras.visualprospecting.utils.VPByteBufUtils;
 import cpw.mods.fml.common.network.simpleimpl.IMessage;
 import cpw.mods.fml.common.network.simpleimpl.IMessageHandler;
 import cpw.mods.fml.common.network.simpleimpl.MessageContext;
 import io.netty.buffer.ByteBuf;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
 
 public class ProspectingNotification implements IMessage {
 
@@ -40,54 +34,14 @@ public class ProspectingNotification implements IMessage {
 
     @Override
     public void fromBytes(ByteBuf buf) {
-        final int numberOfOreVeins = buf.readInt();
-        oreVeins = new ArrayList<>(numberOfOreVeins);
-        for (int i = 0; i < numberOfOreVeins; i++) {
-            final int dimensionId = buf.readInt();
-            final int chunkX = buf.readInt();
-            final int chunkZ = buf.readInt();
-            final String oreVeinName = ByteBufUtils.readUTF8String(buf);
-            oreVeins.add(new OreVeinPosition(dimensionId, chunkX, chunkZ, VeinTypeCaching.getVeinType(oreVeinName)));
-        }
-
-        final int numberOfUndergroundFluids = buf.readInt();
-        undergroundFluids = new ArrayList<>(numberOfUndergroundFluids);
-        for (int i = 0; i < numberOfUndergroundFluids; i++) {
-            final int dimensionId = buf.readInt();
-            final int chunkX = buf.readInt();
-            final int chunkZ = buf.readInt();
-            final Fluid fluid = FluidRegistry.getFluid(buf.readInt());
-            final int[][] chunks = new int[VP.undergroundFluidSizeChunkX][VP.undergroundFluidSizeChunkZ];
-            for (int offsetChunkX = 0; offsetChunkX < VP.undergroundFluidSizeChunkX; offsetChunkX++)
-                for (int offsetChunkZ = 0; offsetChunkZ < VP.undergroundFluidSizeChunkZ; offsetChunkZ++) {
-                    chunks[offsetChunkX][offsetChunkZ] = buf.readInt();
-                }
-            undergroundFluids.add(new UndergroundFluidPosition(dimensionId, chunkX, chunkZ, fluid, chunks));
-        }
+        oreVeins.addAll(VPByteBufUtils.ReadOreVeinPositions(buf));
+        undergroundFluids.addAll(VPByteBufUtils.ReadUndergroundFluidPositions(buf));
     }
 
     @Override
     public void toBytes(ByteBuf buf) {
-        buf.writeInt(oreVeins.size());
-        for (OreVeinPosition oreVein : oreVeins) {
-            buf.writeInt(oreVein.dimensionId);
-            buf.writeInt(oreVein.chunkX);
-            buf.writeInt(oreVein.chunkZ);
-            ByteBufUtils.writeUTF8String(buf, oreVein.veinType.name);
-        }
-
-        buf.writeInt(undergroundFluids.size());
-        for (UndergroundFluidPosition undergroundFluid : undergroundFluids) {
-            buf.writeInt(undergroundFluid.dimensionId);
-            buf.writeInt(undergroundFluid.chunkX);
-            buf.writeInt(undergroundFluid.chunkZ);
-            buf.writeInt(undergroundFluid.fluid.getID());
-            for (int offsetChunkX = 0; offsetChunkX < VP.undergroundFluidSizeChunkX; offsetChunkX++) {
-                for (int offsetChunkZ = 0; offsetChunkZ < VP.undergroundFluidSizeChunkZ; offsetChunkZ++) {
-                    buf.writeInt(undergroundFluid.chunks[offsetChunkX][offsetChunkZ]);
-                }
-            }
-        }
+        VPByteBufUtils.WriteOreVeinPositions(buf, oreVeins);
+        VPByteBufUtils.WriteUndergroundFluidPositions(buf, undergroundFluids);
     }
 
     public static class Handler implements IMessageHandler<ProspectingNotification, IMessage> {

--- a/src/main/java/com/sinthoras/visualprospecting/network/ProspectingNotification.java
+++ b/src/main/java/com/sinthoras/visualprospecting/network/ProspectingNotification.java
@@ -1,17 +1,18 @@
 package com.sinthoras.visualprospecting.network;
 
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
 import com.sinthoras.visualprospecting.database.ClientCache;
 import com.sinthoras.visualprospecting.database.OreVeinPosition;
 import com.sinthoras.visualprospecting.database.UndergroundFluidPosition;
 import com.sinthoras.visualprospecting.utils.VPByteBufUtils;
+
 import cpw.mods.fml.common.network.simpleimpl.IMessage;
 import cpw.mods.fml.common.network.simpleimpl.IMessageHandler;
 import cpw.mods.fml.common.network.simpleimpl.MessageContext;
 import io.netty.buffer.ByteBuf;
-
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
 
 public class ProspectingNotification implements IMessage {
 

--- a/src/main/java/com/sinthoras/visualprospecting/network/ProspectingNotification.java
+++ b/src/main/java/com/sinthoras/visualprospecting/network/ProspectingNotification.java
@@ -35,8 +35,8 @@ public class ProspectingNotification implements IMessage {
 
     @Override
     public void fromBytes(ByteBuf buf) {
-        oreVeins.addAll(VPByteBufUtils.ReadOreVeinPositions(buf));
-        undergroundFluids.addAll(VPByteBufUtils.ReadUndergroundFluidPositions(buf));
+        oreVeins = VPByteBufUtils.ReadOreVeinPositions(buf);
+        undergroundFluids = VPByteBufUtils.ReadUndergroundFluidPositions(buf);
     }
 
     @Override

--- a/src/main/java/com/sinthoras/visualprospecting/network/ProspectionSharing.java
+++ b/src/main/java/com/sinthoras/visualprospecting/network/ProspectionSharing.java
@@ -5,18 +5,15 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import com.sinthoras.visualprospecting.utils.VPByteBufUtils;
 import net.minecraft.entity.player.EntityPlayerMP;
-import net.minecraftforge.fluids.Fluid;
-import net.minecraftforge.fluids.FluidRegistry;
 
 import com.sinthoras.visualprospecting.VP;
 import com.sinthoras.visualprospecting.database.ClientCache;
 import com.sinthoras.visualprospecting.database.OreVeinPosition;
 import com.sinthoras.visualprospecting.database.TransferCache;
 import com.sinthoras.visualprospecting.database.UndergroundFluidPosition;
-import com.sinthoras.visualprospecting.database.veintypes.VeinTypeCaching;
 
-import cpw.mods.fml.common.network.ByteBufUtils;
 import cpw.mods.fml.common.network.simpleimpl.IMessage;
 import cpw.mods.fml.common.network.simpleimpl.IMessageHandler;
 import cpw.mods.fml.common.network.simpleimpl.MessageContext;
@@ -36,10 +33,10 @@ public class ProspectionSharing implements IMessage {
 
     public int putOreVeins(List<OreVeinPosition> oreVeins) {
         final int availableBytes = VP.uploadSizePerPacketInBytes - bytesUsed;
-        final int maxAddedOreVeins = availableBytes / OreVeinPosition.getMaxBytes();
+        final int maxAddedOreVeins = availableBytes / OreVeinPosition.MAX_BYTES;
         final int addedOreVeins = Math.min(oreVeins.size(), maxAddedOreVeins);
         this.oreVeins.addAll(oreVeins.subList(0, addedOreVeins));
-        bytesUsed += addedOreVeins * OreVeinPosition.getMaxBytes();
+        bytesUsed += addedOreVeins * OreVeinPosition.MAX_BYTES;
         return addedOreVeins;
     }
 
@@ -61,7 +58,7 @@ public class ProspectionSharing implements IMessage {
     }
 
     public int getBytes() {
-        return BYTES_OVERHEAD + VeinTypeCaching.getLongesOreNameLength() * oreVeins.size()
+        return BYTES_OVERHEAD + OreVeinPosition.MAX_BYTES * oreVeins.size()
                 + UndergroundFluidPosition.BYTES * undergroundFluids.size();
     }
 
@@ -70,35 +67,8 @@ public class ProspectionSharing implements IMessage {
         isFirstMessage = buf.readByte() > 0;
         isLastMessage = buf.readByte() > 0;
 
-        final int numberOfOreVeins = buf.readInt();
-        for (int i = 0; i < numberOfOreVeins; i++) {
-            final int dimensionId = buf.readInt();
-            final int chunkX = buf.readInt();
-            final int chunkZ = buf.readInt();
-            final boolean isDepleted = buf.readByte() > 0;
-            final String oreVeinName = ByteBufUtils.readUTF8String(buf);
-            oreVeins.add(
-                    new OreVeinPosition(
-                            dimensionId,
-                            chunkX,
-                            chunkZ,
-                            VeinTypeCaching.getVeinType(oreVeinName),
-                            isDepleted));
-        }
-
-        final int numberOfUndergroundFluids = buf.readInt();
-        for (int i = 0; i < numberOfUndergroundFluids; i++) {
-            final int dimensionId = buf.readInt();
-            final int chunkX = buf.readInt();
-            final int chunkZ = buf.readInt();
-            final Fluid fluid = FluidRegistry.getFluid(buf.readInt());
-            final int[][] chunks = new int[VP.undergroundFluidSizeChunkX][VP.undergroundFluidSizeChunkZ];
-            for (int offsetChunkX = 0; offsetChunkX < VP.undergroundFluidSizeChunkX; offsetChunkX++)
-                for (int offsetChunkZ = 0; offsetChunkZ < VP.undergroundFluidSizeChunkZ; offsetChunkZ++) {
-                    chunks[offsetChunkX][offsetChunkZ] = buf.readInt();
-                }
-            undergroundFluids.add(new UndergroundFluidPosition(dimensionId, chunkX, chunkZ, fluid, chunks));
-        }
+        oreVeins.addAll(VPByteBufUtils.ReadOreVeinPositions(buf));
+        undergroundFluids.addAll(VPByteBufUtils.ReadUndergroundFluidPositions(buf));
     }
 
     @Override
@@ -106,27 +76,8 @@ public class ProspectionSharing implements IMessage {
         buf.writeByte(isFirstMessage ? 1 : 0);
         buf.writeByte(isLastMessage ? 1 : 0);
 
-        buf.writeInt(oreVeins.size());
-        for (OreVeinPosition oreVein : oreVeins) {
-            buf.writeInt(oreVein.dimensionId);
-            buf.writeInt(oreVein.chunkX);
-            buf.writeInt(oreVein.chunkZ);
-            buf.writeByte(oreVein.isDepleted() ? 1 : 0);
-            ByteBufUtils.writeUTF8String(buf, oreVein.veinType.name);
-        }
-
-        buf.writeInt(undergroundFluids.size());
-        for (UndergroundFluidPosition undergroundFluid : undergroundFluids) {
-            buf.writeInt(undergroundFluid.dimensionId);
-            buf.writeInt(undergroundFluid.chunkX);
-            buf.writeInt(undergroundFluid.chunkZ);
-            buf.writeInt(undergroundFluid.fluid.getID());
-            for (int offsetChunkX = 0; offsetChunkX < VP.undergroundFluidSizeChunkX; offsetChunkX++) {
-                for (int offsetChunkZ = 0; offsetChunkZ < VP.undergroundFluidSizeChunkZ; offsetChunkZ++) {
-                    buf.writeInt(undergroundFluid.chunks[offsetChunkX][offsetChunkZ]);
-                }
-            }
-        }
+        VPByteBufUtils.WriteOreVeinPositions(buf, oreVeins);
+        VPByteBufUtils.WriteUndergroundFluidPositions(buf, undergroundFluids);
     }
 
     public static class ServerHandler implements IMessageHandler<ProspectionSharing, IMessage> {

--- a/src/main/java/com/sinthoras/visualprospecting/network/ProspectionSharing.java
+++ b/src/main/java/com/sinthoras/visualprospecting/network/ProspectionSharing.java
@@ -5,7 +5,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import com.sinthoras.visualprospecting.utils.VPByteBufUtils;
 import net.minecraft.entity.player.EntityPlayerMP;
 
 import com.sinthoras.visualprospecting.VP;
@@ -13,6 +12,7 @@ import com.sinthoras.visualprospecting.database.ClientCache;
 import com.sinthoras.visualprospecting.database.OreVeinPosition;
 import com.sinthoras.visualprospecting.database.TransferCache;
 import com.sinthoras.visualprospecting.database.UndergroundFluidPosition;
+import com.sinthoras.visualprospecting.utils.VPByteBufUtils;
 
 import cpw.mods.fml.common.network.simpleimpl.IMessage;
 import cpw.mods.fml.common.network.simpleimpl.IMessageHandler;

--- a/src/main/java/com/sinthoras/visualprospecting/utils/VPByteBufUtils.java
+++ b/src/main/java/com/sinthoras/visualprospecting/utils/VPByteBufUtils.java
@@ -1,15 +1,17 @@
 package com.sinthoras.visualprospecting.utils;
 
+import java.util.ArrayList;
+import java.util.List;
+
+import net.minecraftforge.fluids.Fluid;
+import net.minecraftforge.fluids.FluidRegistry;
+
 import com.sinthoras.visualprospecting.VP;
 import com.sinthoras.visualprospecting.database.OreVeinPosition;
 import com.sinthoras.visualprospecting.database.UndergroundFluidPosition;
 import com.sinthoras.visualprospecting.database.veintypes.VeinTypeCaching;
-import io.netty.buffer.ByteBuf;
-import net.minecraftforge.fluids.Fluid;
-import net.minecraftforge.fluids.FluidRegistry;
 
-import java.util.ArrayList;
-import java.util.List;
+import io.netty.buffer.ByteBuf;
 
 public final class VPByteBufUtils {
 
@@ -76,7 +78,8 @@ public final class VPByteBufUtils {
         return oreVeinPositions;
     }
 
-    public static void WriteUndergroundFluidPositions(ByteBuf buf, List<UndergroundFluidPosition> undergroundFluidPositions) {
+    public static void WriteUndergroundFluidPositions(ByteBuf buf,
+            List<UndergroundFluidPosition> undergroundFluidPositions) {
         buf.writeInt(undergroundFluidPositions.size());
         for (UndergroundFluidPosition undergroundFluidPosition : undergroundFluidPositions) {
             WriteUndergroundFluidPosition(buf, undergroundFluidPosition);

--- a/src/main/java/com/sinthoras/visualprospecting/utils/VPByteBufUtils.java
+++ b/src/main/java/com/sinthoras/visualprospecting/utils/VPByteBufUtils.java
@@ -1,0 +1,96 @@
+package com.sinthoras.visualprospecting.utils;
+
+import com.sinthoras.visualprospecting.VP;
+import com.sinthoras.visualprospecting.database.OreVeinPosition;
+import com.sinthoras.visualprospecting.database.UndergroundFluidPosition;
+import com.sinthoras.visualprospecting.database.veintypes.VeinTypeCaching;
+import io.netty.buffer.ByteBuf;
+import net.minecraftforge.fluids.Fluid;
+import net.minecraftforge.fluids.FluidRegistry;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public final class VPByteBufUtils {
+
+    public static void WriteOreVeinPosition(ByteBuf buf, OreVeinPosition oreVeinPosition) {
+        buf.writeInt(oreVeinPosition.dimensionId);
+        buf.writeInt(oreVeinPosition.chunkX);
+        buf.writeInt(oreVeinPosition.chunkZ);
+        buf.writeShort(oreVeinPosition.veinType.veinId);
+        buf.writeBoolean(oreVeinPosition.isDepleted());
+    }
+
+    public static OreVeinPosition ReadOreVeinPosition(ByteBuf buf) {
+        final int dimId = buf.readInt();
+        final int chunkX = buf.readInt();
+        final int chunkZ = buf.readInt();
+        final short veinId = buf.readShort();
+        final boolean isDepleted = buf.readBoolean();
+
+        return new OreVeinPosition(dimId, chunkX, chunkZ, VeinTypeCaching.getVeinType(veinId), isDepleted);
+    }
+
+    public static void WriteUndergroundFluidPosition(ByteBuf buf, UndergroundFluidPosition undergroundFluidPosition) {
+        buf.writeInt(undergroundFluidPosition.dimensionId);
+        buf.writeInt(undergroundFluidPosition.chunkX);
+        buf.writeInt(undergroundFluidPosition.chunkZ);
+        buf.writeInt(undergroundFluidPosition.fluid.getID());
+        for (int offsetChunkX = 0; offsetChunkX < VP.undergroundFluidSizeChunkX; offsetChunkX++) {
+            for (int offsetChunkZ = 0; offsetChunkZ < VP.undergroundFluidSizeChunkZ; offsetChunkZ++) {
+                buf.writeInt(undergroundFluidPosition.chunks[offsetChunkX][offsetChunkZ]);
+            }
+        }
+    }
+
+    public static UndergroundFluidPosition ReadUndergroundFluidPosition(ByteBuf buf) {
+        final int dimId = buf.readInt();
+        final int chunkX = buf.readInt();
+        final int chunkZ = buf.readInt();
+        final Fluid fluid = FluidRegistry.getFluid(buf.readInt());
+        final int[][] chunks = new int[VP.undergroundFluidSizeChunkX][VP.undergroundFluidSizeChunkZ];
+        for (int offsetChunkX = 0; offsetChunkX < VP.undergroundFluidSizeChunkX; offsetChunkX++) {
+            for (int offsetChunkZ = 0; offsetChunkZ < VP.undergroundFluidSizeChunkZ; offsetChunkZ++) {
+                chunks[offsetChunkX][offsetChunkZ] = buf.readInt();
+            }
+        }
+
+        return new UndergroundFluidPosition(dimId, chunkX, chunkZ, fluid, chunks);
+    }
+
+    public static void WriteOreVeinPositions(ByteBuf buf, List<OreVeinPosition> oreVeinPositions) {
+        buf.writeInt(oreVeinPositions.size());
+        for (OreVeinPosition oreVeinPosition : oreVeinPositions) {
+            WriteOreVeinPosition(buf, oreVeinPosition);
+        }
+    }
+
+    public static List<OreVeinPosition> ReadOreVeinPositions(ByteBuf buf) {
+        List<OreVeinPosition> oreVeinPositions = new ArrayList<>();
+
+        final int oreVeinCount = buf.readInt();
+        for (int i = 0; i < oreVeinCount; i++) {
+            oreVeinPositions.add(ReadOreVeinPosition(buf));
+        }
+
+        return oreVeinPositions;
+    }
+
+    public static void WriteUndergroundFluidPositions(ByteBuf buf, List<UndergroundFluidPosition> undergroundFluidPositions) {
+        buf.writeInt(undergroundFluidPositions.size());
+        for (UndergroundFluidPosition undergroundFluidPosition : undergroundFluidPositions) {
+            WriteUndergroundFluidPosition(buf, undergroundFluidPosition);
+        }
+    }
+
+    public static List<UndergroundFluidPosition> ReadUndergroundFluidPositions(ByteBuf buf) {
+        List<UndergroundFluidPosition> undergroundFluidPositions = new ArrayList<>();
+
+        final int undergroundFluidCount = buf.readInt();
+        for (int i = 0; i < undergroundFluidCount; i++) {
+            undergroundFluidPositions.add(ReadUndergroundFluidPosition(buf));
+        }
+
+        return undergroundFluidPositions;
+    }
+}


### PR DESCRIPTION
- Abstracts serialization/de-serialization logic for `OreVeinPosition` and `UndergroundFluidPosition` to a utility class `VPByteBufUtils`
- OreVeinPositions use their Id instead of their Name when serializing/de-serializing for packets
- OreVeinPositions now have a constant size when serializing/de-serializing, fixing a potential future edge case