### PR TITLE
Show empty fluid fields on map

### DIFF
--- a/src/main/java/com/sinthoras/visualprospecting/integration/journeymap/drawsteps/UndergroundFluidDrawStep.java
+++ b/src/main/java/com/sinthoras/visualprospecting/integration/journeymap/drawsteps/UndergroundFluidDrawStep.java
@@ -2,6 +2,8 @@ package com.sinthoras.visualprospecting.integration.journeymap.drawsteps;
 
 import java.awt.geom.Point2D;
 
+import net.minecraft.client.resources.I18n;
+
 import com.sinthoras.visualprospecting.VP;
 import com.sinthoras.visualprospecting.integration.model.locations.UndergroundFluidLocation;
 
@@ -17,67 +19,68 @@ public class UndergroundFluidDrawStep implements DrawStep {
         this.undergroundFluidLocation = undergroundFluidLocation;
     }
 
+    @SuppressWarnings("deprecation")
     @Override
     public void draw(double draggedPixelX, double draggedPixelY, GridRenderer gridRenderer, float drawScale,
             double fontScale, double rotation) {
         final int maxAmountInField = undergroundFluidLocation.getMaxProduction();
+        final double blockSize = Math.pow(2, gridRenderer.getZoom());
+        final Point2D.Double blockAsPixel = gridRenderer
+                .getBlockPixelInGrid(undergroundFluidLocation.getBlockX(), undergroundFluidLocation.getBlockZ());
+        final Point2D.Double pixel = new Point2D.Double(
+                blockAsPixel.getX() + draggedPixelX,
+                blockAsPixel.getY() + draggedPixelY);
+
+        final int borderColor = undergroundFluidLocation.getFluid().getColor();
+        final int borderAlpha = 204;
+        DrawUtil.drawRectangle(
+                pixel.getX(),
+                pixel.getY(),
+                VP.undergroundFluidSizeChunkX * VP.chunkWidth * blockSize,
+                2 * blockSize,
+                borderColor,
+                borderAlpha);
+        DrawUtil.drawRectangle(
+                pixel.getX() + VP.undergroundFluidSizeChunkX * VP.chunkWidth * blockSize,
+                pixel.getY(),
+                2 * blockSize,
+                VP.undergroundFluidSizeChunkZ * VP.chunkDepth * blockSize,
+                borderColor,
+                borderAlpha);
+        DrawUtil.drawRectangle(
+                pixel.getX() + 2 * blockSize,
+                pixel.getY() + VP.undergroundFluidSizeChunkZ * VP.chunkDepth * blockSize,
+                VP.undergroundFluidSizeChunkX * VP.chunkWidth * blockSize,
+                2 * blockSize,
+                borderColor,
+                borderAlpha);
+        DrawUtil.drawRectangle(
+                pixel.getX(),
+                pixel.getY() + 2 * blockSize,
+                2 * blockSize,
+                VP.undergroundFluidSizeChunkZ * VP.chunkDepth * blockSize,
+                borderColor,
+                borderAlpha);
+
+        String label = I18n.format("visualprospecting.empty");
         if (maxAmountInField > 0) {
-            final double blockSize = Math.pow(2, gridRenderer.getZoom());
-            final Point2D.Double blockAsPixel = gridRenderer
-                    .getBlockPixelInGrid(undergroundFluidLocation.getBlockX(), undergroundFluidLocation.getBlockZ());
-            final Point2D.Double pixel = new Point2D.Double(
-                    blockAsPixel.getX() + draggedPixelX,
-                    blockAsPixel.getY() + draggedPixelY);
-
-            final int borderColor = undergroundFluidLocation.getFluid().getColor();
-            final int borderAlpha = 204;
-            DrawUtil.drawRectangle(
-                    pixel.getX(),
-                    pixel.getY(),
-                    VP.undergroundFluidSizeChunkX * VP.chunkWidth * blockSize,
-                    2 * blockSize,
-                    borderColor,
-                    borderAlpha);
-            DrawUtil.drawRectangle(
-                    pixel.getX() + VP.undergroundFluidSizeChunkX * VP.chunkWidth * blockSize,
-                    pixel.getY(),
-                    2 * blockSize,
-                    VP.undergroundFluidSizeChunkZ * VP.chunkDepth * blockSize,
-                    borderColor,
-                    borderAlpha);
-            DrawUtil.drawRectangle(
-                    pixel.getX() + 2 * blockSize,
-                    pixel.getY() + VP.undergroundFluidSizeChunkZ * VP.chunkDepth * blockSize,
-                    VP.undergroundFluidSizeChunkX * VP.chunkWidth * blockSize,
-                    2 * blockSize,
-                    borderColor,
-                    borderAlpha);
-            DrawUtil.drawRectangle(
-                    pixel.getX(),
-                    pixel.getY() + 2 * blockSize,
-                    2 * blockSize,
-                    VP.undergroundFluidSizeChunkZ * VP.chunkDepth * blockSize,
-                    borderColor,
-                    borderAlpha);
-
-            @SuppressWarnings("deprecation")
-            final String label = undergroundFluidLocation.getMinProduction() + "L - "
+            label = undergroundFluidLocation.getMinProduction() + "L - "
                     + maxAmountInField
                     + "L  "
                     + undergroundFluidLocation.getFluid().getLocalizedName();
-            DrawUtil.drawLabel(
-                    label,
-                    pixel.getX() + VP.chunkWidth * blockSize,
-                    pixel.getY(),
-                    DrawUtil.HAlign.Right,
-                    DrawUtil.VAlign.Below,
-                    0,
-                    180,
-                    0x00FFFFFF,
-                    255,
-                    fontScale,
-                    false,
-                    rotation);
         }
+        DrawUtil.drawLabel(
+                label,
+                pixel.getX() + VP.chunkWidth * (blockSize * 4),
+                pixel.getY(),
+                DrawUtil.HAlign.Center,
+                DrawUtil.VAlign.Below,
+                0,
+                180,
+                0x00FFFFFF,
+                255,
+                fontScale,
+                false,
+                rotation);
     }
 }

--- a/src/main/java/com/sinthoras/visualprospecting/integration/xaeroworldmap/rendersteps/UndergroundFluidRenderStep.java
+++ b/src/main/java/com/sinthoras/visualprospecting/integration/xaeroworldmap/rendersteps/UndergroundFluidRenderStep.java
@@ -3,6 +3,7 @@ package com.sinthoras.visualprospecting.integration.xaeroworldmap.rendersteps;
 import javax.annotation.Nullable;
 
 import net.minecraft.client.gui.GuiScreen;
+import net.minecraft.client.resources.I18n;
 
 import org.lwjgl.opengl.GL11;
 
@@ -18,11 +19,12 @@ public class UndergroundFluidRenderStep implements RenderStep {
         undergroundFluidLocation = undergroundFluid;
     }
 
+    @SuppressWarnings("deprecation")
     @Override
     public void draw(@Nullable GuiScreen gui, double cameraX, double cameraZ, double scale) {
         final int maxAmountInField = undergroundFluidLocation.getMaxProduction();
         // < 0.5 scale is when scaling issues show up
-        if (maxAmountInField > 0 && scale >= 0.5) {
+        if (scale >= 0.5) {
             GL11.glPushMatrix();
             GL11.glTranslated(
                     undergroundFluidLocation.getBlockX() - 0.5 - cameraX,
@@ -40,11 +42,13 @@ public class UndergroundFluidRenderStep implements RenderStep {
             // min scale that journeymap can go to
             if (scale >= 1 && gui != null) {
                 GL11.glScaled(1 / scale, 1 / scale, 1);
-                @SuppressWarnings("deprecation")
-                final String label = undergroundFluidLocation.getMinProduction() + "L - "
-                        + maxAmountInField
-                        + "L  "
-                        + undergroundFluidLocation.getFluid().getLocalizedName();
+                String label = I18n.format("visualprospecting.empty");
+                if (maxAmountInField > 0) {
+                    label = undergroundFluidLocation.getMinProduction() + "L - "
+                            + maxAmountInField
+                            + "L  "
+                            + undergroundFluidLocation.getFluid().getLocalizedName();
+                }
                 DrawUtils.drawSimpleLabel(gui, label, VP.chunkWidth * scale, 0, 0xFFFFFFFF, 0xB4000000, false);
             }
 

--- a/src/main/resources/assets/visualprospecting/lang/en_US.lang
+++ b/src/main/resources/assets/visualprospecting/lang/en_US.lang
@@ -27,6 +27,7 @@ visualprospecting.redoserverspawncache.confirmation=Redo success!
 visualprospecting.iswaypoint=Active as Waypoint
 visualprospecting.depleted=DEPLETED
 visualprospecting.depleted.toggle=Toggle depleted with %s
+visualprospecting.empty=Empty
 visualprospecting.key.action.name=Action button
 visualprospecting.key.toggleore.name=Toggle ore overlay
 visualprospecting.key.togglefluid.name=Toggle fluid overlay


### PR DESCRIPTION
Works on both JourneyMap and Xaero's.
![jmap-full](https://github.com/GTNewHorizons/VisualProspecting/assets/127234178/5947f070-f450-48b7-bbef-da1aae99cf4a)

I also took the liberty of centering the JourneyMap label as it would sometimes draw past the right border which just looks off imo.

Pre label:
![jmap-label-pre](https://github.com/GTNewHorizons/VisualProspecting/assets/127234178/1fad3758-c534-48a1-916f-0bbf791c1f39)
<details>
  <summary>Full Map without centered label</summary>
 

There's quite a few drawing past the border
![pre-full](https://github.com/GTNewHorizons/VisualProspecting/assets/127234178/45934019-cedd-4e93-b414-d2bd312bf76e)
</details>

Centered label:
![jmap-label](https://github.com/GTNewHorizons/VisualProspecting/assets/127234178/7c66eb99-89ee-40bb-ab9a-9af4b2bd2b51)

Closes: https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/15400
