### PR TITLE
Enable layers to do actions outside rendered drawsteps

### DIFF
--- a/src/main/java/com/sinthoras/visualprospecting/integration/journeymap/render/WaypointProviderLayerRenderer.java
+++ b/src/main/java/com/sinthoras/visualprospecting/integration/journeymap/render/WaypointProviderLayerRenderer.java
@@ -10,6 +10,8 @@ import com.sinthoras.visualprospecting.integration.journeymap.drawsteps.Clickabl
 import com.sinthoras.visualprospecting.integration.model.layers.WaypointProviderManager;
 import com.sinthoras.visualprospecting.integration.model.locations.ILocationProvider;
 
+import journeymap.client.model.BlockCoordIntPair;
+
 public abstract class WaypointProviderLayerRenderer extends LayerRenderer {
 
     private final WaypointProviderManager manager;
@@ -64,6 +66,13 @@ public abstract class WaypointProviderLayerRenderer extends LayerRenderer {
                 }
             }
             return true;
+        }
+        return false;
+    }
+
+    public boolean onMouseActionOutsideLayer(boolean isDoubleClick, BlockCoordIntPair blockCoord) {
+        if (isLayerActive() && isDoubleClick) {
+            return manager.doActionOutsideLayer(blockCoord);
         }
         return false;
     }

--- a/src/main/java/com/sinthoras/visualprospecting/integration/model/layers/WaypointProviderManager.java
+++ b/src/main/java/com/sinthoras/visualprospecting/integration/model/layers/WaypointProviderManager.java
@@ -11,6 +11,8 @@ import com.sinthoras.visualprospecting.integration.model.locations.IWaypointAndL
 import com.sinthoras.visualprospecting.integration.model.waypoints.Waypoint;
 import com.sinthoras.visualprospecting.integration.model.waypoints.WaypointManager;
 
+import journeymap.client.model.BlockCoordIntPair;
+
 public abstract class WaypointProviderManager extends LayerManager {
 
     private List<? extends IWaypointAndLocationProvider> visibleElements = new ArrayList<>();
@@ -36,6 +38,10 @@ public abstract class WaypointProviderManager extends LayerManager {
 
     public boolean hasActiveWaypoint() {
         return activeWaypoint != null;
+    }
+
+    public boolean doActionOutsideLayer(BlockCoordIntPair blockCoord) {
+        return false;
     }
 
     public void registerWaypointManager(SupportedMods map, WaypointManager waypointManager) {


### PR DESCRIPTION
This is primarily aimed at an incoming [Server Utilities pr ](https://github.com/GTNewHorizons/ServerUtilities/pull/41)to allow players to claim chunks from JourneyMap.

Just extends some basic functionality for the various layers to do actions outside of the rendered drawsteps provided the layer is active. Doesn't affect any of the current VP layers.