### PR TITLE
Fix Scaling of GT Ore Veins and TC Nodes on Journeymap

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -1,10 +1,10 @@
 dependencies {
     shadowImplementation('com.github.GTNewHorizons:Enklume:2.1.0:dev')
 
-    api('com.github.GTNewHorizons:GT5-Unofficial:5.09.48.37:dev')
+    api('com.github.GTNewHorizons:GT5-Unofficial:5.09.48.56:dev')
     api(rfg.deobf('maven.modrinth:journeymap:5.2.3'))
 
-    devOnlyNonPublishable('com.github.GTNewHorizons:TCNodeTracker:1.2.0:dev')
+    devOnlyNonPublishable('com.github.GTNewHorizons:TCNodeTracker:1.3.0:dev')
 
     compileOnly(deobfCurse('xaeros-minimap-263420:4905582'))
     compileOnly(deobfCurse('xaeros-world-map-317780:4905612'))
@@ -12,5 +12,5 @@ dependencies {
 
     // For debugging
     runtimeOnlyNonPublishable('com.github.GTNewHorizons:DetravScannerMod:1.8.1:dev')
-    runtimeOnlyNonPublishable('com.github.GTNewHorizons:ServerUtilities:2.0.51:dev')
+    runtimeOnlyNonPublishable('com.github.GTNewHorizons:ServerUtilities:2.0.60:dev')
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.8-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/settings.gradle
+++ b/settings.gradle
@@ -17,7 +17,7 @@ pluginManagement {
 }
 
 plugins {
-    id 'com.gtnewhorizons.gtnhsettingsconvention' version '1.0.22'
+    id 'com.gtnewhorizons.gtnhsettingsconvention' version '1.0.23'
 }
 
 

--- a/src/main/java/com/sinthoras/visualprospecting/integration/journeymap/drawsteps/OreVeinDrawStep.java
+++ b/src/main/java/com/sinthoras/visualprospecting/integration/journeymap/drawsteps/OreVeinDrawStep.java
@@ -72,7 +72,7 @@ public class OreVeinDrawStep implements ClickableDrawStep {
     @Override
     public void draw(double draggedPixelX, double draggedPixelY, GridRenderer gridRenderer, float drawScale,
             double fontScale, double rotation) {
-        iconSize = 32 * fontScale;
+        iconSize = 32 * drawScale;
         final double iconSizeHalf = iconSize / 2;
         final Point2D.Double blockAsPixel = gridRenderer
                 .getBlockPixelInGrid(oreVeinLocation.getBlockX(), oreVeinLocation.getBlockZ());

--- a/src/main/java/com/sinthoras/visualprospecting/integration/journeymap/drawsteps/ThaumcraftNodeDrawStep.java
+++ b/src/main/java/com/sinthoras/visualprospecting/integration/journeymap/drawsteps/ThaumcraftNodeDrawStep.java
@@ -42,7 +42,7 @@ public class ThaumcraftNodeDrawStep implements ClickableDrawStep {
     @Override
     public void draw(double draggedPixelX, double draggedPixelY, GridRenderer gridRenderer, float drawScale,
             double fontScale, double rotation) {
-        final double borderSize = 44 * fontScale;
+        final double borderSize = 44 * drawScale;
         final double borderSizeHalf = borderSize / 2;
         final Point2D.Double blockAsPixel = gridRenderer
                 .getBlockPixelInGrid(thaumcraftNodeLocation.getBlockX(), thaumcraftNodeLocation.getBlockZ());


### PR DESCRIPTION
Fixes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/16598

Minimap:
![image](https://github.com/GTNewHorizons/VisualProspecting/assets/18713839/1bd66d52-55bf-4f3b-8a1f-658da9b293a8)
![image](https://github.com/GTNewHorizons/VisualProspecting/assets/18713839/29d9a28b-9ca5-4edc-b0b6-2f344cb79f9e)

Fullmap:
![image](https://github.com/GTNewHorizons/VisualProspecting/assets/18713839/fb2ac571-aebd-4c4c-9743-b65ffa5e307b)
![image](https://github.com/GTNewHorizons/VisualProspecting/assets/18713839/c8f99f8d-50d6-4976-a364-6d6179ead1d0)
