### PR TITLE
More optimization & bug fixes

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -3,6 +3,5 @@ dependencies {
     api('com.github.GTNewHorizons:GTNHLib:0.5.11:dev')
     api('com.github.GTNewHorizons:GT5-Unofficial:5.09.49.107:dev')
 
-    runtimeOnlyNonPublishable(rfg.deobf('maven.modrinth:journeymap:5.2.5'))
     runtimeOnlyNonPublishable(rfg.deobf('maven.modrinth:journeymap:5.2.6'))
 }

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -1,7 +1,7 @@
 dependencies {
     api('com.github.GTNewHorizons:Navigator:1.0.12:dev')
     api('com.github.GTNewHorizons:GTNHLib:0.5.11:dev')
-    api('com.github.GTNewHorizons:GT5-Unofficial:5.09.49.107:dev')
+    api('com.github.GTNewHorizons:GT5-Unofficial:5.09.49.111:dev')
 
     runtimeOnlyNonPublishable(rfg.deobf('maven.modrinth:journeymap:5.2.6'))
 }

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -1,7 +1,7 @@
 dependencies {
     api('com.github.GTNewHorizons:Navigator:1.0.12:dev')
     api('com.github.GTNewHorizons:GTNHLib:0.5.11:dev')
-    api('com.github.GTNewHorizons:GT5-Unofficial:5.09.49.111:dev')
+    api('com.github.GTNewHorizons:GT5-Unofficial:5.09.50.01:dev')
 
     runtimeOnlyNonPublishable(rfg.deobf('maven.modrinth:journeymap:5.2.6'))
 }

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -1,7 +1,7 @@
 dependencies {
     api('com.github.GTNewHorizons:Navigator:1.0.12:dev')
     api('com.github.GTNewHorizons:GTNHLib:0.5.11:dev')
-    api('com.github.GTNewHorizons:GT5-Unofficial:5.09.49.105:dev')
+    api('com.github.GTNewHorizons:GT5-Unofficial:5.09.49.107:dev')
 
     runtimeOnlyNonPublishable(rfg.deobf('maven.modrinth:journeymap:5.2.5'))
     runtimeOnlyNonPublishable(rfg.deobf('maven.modrinth:journeymap:5.2.6'))

--- a/src/main/java/com/sinthoras/visualprospecting/database/ClientCache.java
+++ b/src/main/java/com/sinthoras/visualprospecting/database/ClientCache.java
@@ -6,7 +6,6 @@ import java.util.List;
 
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.entity.EntityClientPlayerMP;
-import net.minecraft.client.resources.I18n;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.ChatComponentTranslation;
@@ -39,7 +38,7 @@ public class ClientCache extends WorldCache {
         final String location = "(" + (oreVeinPosition.getBlockX() + 8) + "," + (oreVeinPosition.getBlockZ() + 8) + ")";
         final IChatComponent veinNotification = new ChatComponentTranslation(
                 "visualprospecting.vein.prospected",
-                I18n.format(oreVeinPosition.veinType.name),
+                oreVeinPosition.veinType.getPrimaryOreName(),
                 location);
         veinNotification.getChatStyle().setItalic(true);
         veinNotification.getChatStyle().setColor(EnumChatFormatting.GRAY);

--- a/src/main/java/com/sinthoras/visualprospecting/database/DimensionCache.java
+++ b/src/main/java/com/sinthoras/visualprospecting/database/DimensionCache.java
@@ -203,13 +203,12 @@ public class DimensionCache {
 
     public OreVeinPosition getOreVein(int chunkX, int chunkZ) {
         final long key = getOreVeinKey(chunkX, chunkZ);
-        return oreChunks.getOrDefault(key, new OreVeinPosition(dimensionId, chunkX, chunkZ, VeinType.NO_VEIN, true));
+        return oreChunks.getOrDefault(key, OreVeinPosition.EMPTY_VEIN);
     }
 
     public UndergroundFluidPosition getUndergroundFluid(int chunkX, int chunkZ) {
         final long key = getUndergroundFluidKey(chunkX, chunkZ);
-        return undergroundFluids
-                .getOrDefault(key, UndergroundFluidPosition.getNotProspected(dimensionId, chunkX, chunkZ));
+        return undergroundFluids.getOrDefault(key, UndergroundFluidPosition.NOT_PROSPECTED);
     }
 
     public Collection<OreVeinPosition> getAllOreVeins() {

--- a/src/main/java/com/sinthoras/visualprospecting/database/OreVeinPosition.java
+++ b/src/main/java/com/sinthoras/visualprospecting/database/OreVeinPosition.java
@@ -6,6 +6,7 @@ import com.sinthoras.visualprospecting.database.veintypes.VeinType;
 public class OreVeinPosition {
 
     public static final int MAX_BYTES = 3 * Integer.BYTES + Short.BYTES;
+    public static final OreVeinPosition EMPTY_VEIN = new OreVeinPosition(0, 0, 0, VeinType.NO_VEIN, true);
 
     public final int dimensionId;
     public final int chunkX;

--- a/src/main/java/com/sinthoras/visualprospecting/database/RedoServerCacheCommand.java
+++ b/src/main/java/com/sinthoras/visualprospecting/database/RedoServerCacheCommand.java
@@ -1,6 +1,8 @@
 package com.sinthoras.visualprospecting.database;
 
 import java.io.IOException;
+import java.util.Collections;
+import java.util.List;
 import java.util.Objects;
 import java.util.zip.DataFormatException;
 
@@ -27,6 +29,11 @@ public class RedoServerCacheCommand extends CommandBase {
     @Override
     public String getCommandUsage(ICommandSender sender) {
         return StatCollector.translateToLocal("visualprospecting.redoservercache.command");
+    }
+
+    @Override
+    public List<String> getCommandAliases() {
+        return Collections.singletonList("vp_recache");
     }
 
     @Override

--- a/src/main/java/com/sinthoras/visualprospecting/database/RedoServerSpawnCacheCommand.java
+++ b/src/main/java/com/sinthoras/visualprospecting/database/RedoServerSpawnCacheCommand.java
@@ -1,6 +1,8 @@
 package com.sinthoras.visualprospecting.database;
 
 import java.io.IOException;
+import java.util.Collections;
+import java.util.List;
 import java.util.Objects;
 import java.util.zip.DataFormatException;
 
@@ -27,6 +29,11 @@ public class RedoServerSpawnCacheCommand extends CommandBase {
     @Override
     public String getCommandUsage(ICommandSender sender) {
         return StatCollector.translateToLocal("visualprospecting.redoserverspawncache.command");
+    }
+
+    @Override
+    public List<String> getCommandAliases() {
+        return Collections.singletonList("vp_recachespawn");
     }
 
     @Override

--- a/src/main/java/com/sinthoras/visualprospecting/database/UndergroundFluidPosition.java
+++ b/src/main/java/com/sinthoras/visualprospecting/database/UndergroundFluidPosition.java
@@ -11,16 +11,13 @@ public class UndergroundFluidPosition {
 
     public static final int BYTES = (3 + 1 + VP.undergroundFluidSizeChunkX * VP.undergroundFluidSizeChunkZ)
             * Integer.BYTES;
+    public static final UndergroundFluidPosition NOT_PROSPECTED = new UndergroundFluidPosition(0, 0, 0, null, null);
 
     public final int dimensionId;
     public final int chunkX;
     public final int chunkZ;
     public final Fluid fluid;
     public final int[][] chunks;
-
-    public static UndergroundFluidPosition getNotProspected(int dimensionId, int chunkX, int chunkZ) {
-        return new UndergroundFluidPosition(dimensionId, chunkX, chunkZ, null, null);
-    }
 
     public UndergroundFluidPosition(int dimensionId, int chunkX, int chunkZ, Fluid fluid, int[][] chunks) {
         this.dimensionId = dimensionId;

--- a/src/main/java/com/sinthoras/visualprospecting/database/WorldCache.java
+++ b/src/main/java/com/sinthoras/visualprospecting/database/WorldCache.java
@@ -31,8 +31,9 @@ public abstract class WorldCache {
         if (loadLegacyVeinCache(worldCache)) return true;
 
         final File[] dimensionFiles = worldCache.listFiles();
-        if (dimensionFiles == null) return false;
+        if (dimensionFiles == null || dimensionFiles.length == 0) return false;
 
+        boolean loadedAny = false;
         for (File dimensionFile : dimensionFiles) {
             final String fileName = dimensionFile.getName();
             if (!dimensionFile.isFile() || !fileName.endsWith(".dat")) {
@@ -46,9 +47,10 @@ public abstract class WorldCache {
             final DimensionCache dimension = new DimensionCache(dimensionId);
             dimension.loadFromNbt(dimCompound);
             dimensions.put(dimensionId, dimension);
+            loadedAny = true;
         }
 
-        return true;
+        return loadedAny;
     }
 
     private boolean loadLegacyVeinCache(File worldCacheDirectory) {

--- a/src/main/java/com/sinthoras/visualprospecting/database/WorldCache.java
+++ b/src/main/java/com/sinthoras/visualprospecting/database/WorldCache.java
@@ -12,7 +12,6 @@ import net.minecraft.util.ChunkCoordinates;
 
 import com.sinthoras.visualprospecting.Tags;
 import com.sinthoras.visualprospecting.Utils;
-import com.sinthoras.visualprospecting.database.veintypes.VeinType;
 
 public abstract class WorldCache {
 
@@ -169,7 +168,7 @@ public abstract class WorldCache {
     public OreVeinPosition getOreVein(int dimensionId, int chunkX, int chunkZ) {
         DimensionCache dimension = dimensions.get(dimensionId);
         if (dimension == null) {
-            return new OreVeinPosition(dimensionId, chunkX, chunkZ, VeinType.NO_VEIN, true);
+            return OreVeinPosition.EMPTY_VEIN;
         }
         return dimension.getOreVein(chunkX, chunkZ);
     }
@@ -186,7 +185,7 @@ public abstract class WorldCache {
     public UndergroundFluidPosition getUndergroundFluid(int dimensionId, int chunkX, int chunkZ) {
         DimensionCache dimension = dimensions.get(dimensionId);
         if (dimension == null) {
-            return UndergroundFluidPosition.getNotProspected(dimensionId, chunkX, chunkZ);
+            return UndergroundFluidPosition.NOT_PROSPECTED;
         }
         return dimension.getUndergroundFluid(chunkX, chunkZ);
     }

--- a/src/main/java/com/sinthoras/visualprospecting/database/cachebuilder/ChunkAnalysis.java
+++ b/src/main/java/com/sinthoras/visualprospecting/database/cachebuilder/ChunkAnalysis.java
@@ -21,7 +21,12 @@ public class ChunkAnalysis {
     private final ObjectSet<VeinType> matchedVeins = new ObjectOpenHashSet<>();
     private final Short2IntMap oreCounts = new Short2IntArrayMap();
     private int minVeinBlockY = VP.minecraftWorldHeight;
-    private short primaryMeta, secondaryMeta;
+    private short primaryMeta;
+    private final String dimName;
+
+    public ChunkAnalysis(String dimName) {
+        this.dimName = dimName;
+    }
 
     public void processMinecraftChunk(final NBTTagList tileEntities) {
         if (tileEntities == null || tileEntities.tagCount() == 0) return;
@@ -29,7 +34,8 @@ public class ChunkAnalysis {
             final NBTTagCompound tile = tileEntities.getCompoundTagAt(i);
             if (tile == null || !tile.hasKey("m")) continue;
 
-            if (!"GT_TileEntity_Ores".equals(tile.getString("id"))) {
+            String id = tile.getString("id");
+            if (!"GT_TileEntity_Ores".equals(id) && !"bw.blockoresTE".equals(id)) {
                 continue;
             }
 
@@ -46,35 +52,20 @@ public class ChunkAnalysis {
         }
 
         if (oreCounts.size() == 1) {
-            primaryMeta = secondaryMeta = oreCounts.keySet().iterator().nextShort();
+            primaryMeta = oreCounts.keySet().iterator().nextShort();
         } else if (oreCounts.size() > 1) {
             ShortList metaCounts = new ShortArrayList(oreCounts.keySet());
             metaCounts.sort((a, b) -> Integer.compare(oreCounts.get(b), oreCounts.get(a)));
             primaryMeta = metaCounts.getShort(0);
-            secondaryMeta = metaCounts.getShort(1);
         }
     }
 
     public boolean matchesSingleVein() {
         if (oreCounts.isEmpty()) return true;
         if (oreCounts.size() > 4) return false;
-        ObjectSet<VeinType> veins = VeinTypeCaching.getVeinTypesForPrimaryMeta(primaryMeta);
-        if (veins.isEmpty()) return trySecondaryMeta();
-
-        veins.stream().filter(veinType -> veinType.matches(oreCounts.keySet())).forEach(matchedVeins::add);
-
-        if (matchedVeins.size() != 1) {
-            matchedVeins.clear();
-            return trySecondaryMeta();
-        }
-
-        return true;
-    }
-
-    private boolean trySecondaryMeta() {
-        if (secondaryMeta == primaryMeta) return false;
-        VeinTypeCaching.getVeinTypesForPrimaryMeta(secondaryMeta).stream()
-                .filter(veinType -> veinType.matches(oreCounts.keySet())).forEach(matchedVeins::add);
+        VeinTypeCaching.veinTypes.stream()
+                .filter(vein -> vein.containsAllFoundOres(oreCounts.keySet(), dimName, primaryMeta))
+                .forEach(matchedVeins::add);
         return matchedVeins.size() <= 1;
     }
 

--- a/src/main/java/com/sinthoras/visualprospecting/database/cachebuilder/ChunkAnalysis.java
+++ b/src/main/java/com/sinthoras/visualprospecting/database/cachebuilder/ChunkAnalysis.java
@@ -64,7 +64,7 @@ public class ChunkAnalysis {
         if (oreCounts.isEmpty()) return true;
         if (oreCounts.size() > 4) return false;
         VeinTypeCaching.veinTypes.stream()
-                .filter(vein -> vein.containsAllFoundOres(oreCounts.keySet(), dimName, primaryMeta))
+                .filter(vein -> vein.containsAllFoundOres(oreCounts.keySet(), dimName, primaryMeta, minVeinBlockY))
                 .forEach(matchedVeins::add);
         return matchedVeins.size() <= 1;
     }

--- a/src/main/java/com/sinthoras/visualprospecting/database/cachebuilder/DetailedChunkAnalysis.java
+++ b/src/main/java/com/sinthoras/visualprospecting/database/cachebuilder/DetailedChunkAnalysis.java
@@ -28,21 +28,23 @@ public class DetailedChunkAnalysis {
     public final int chunkZ;
     // For each height we count how often a ore (short) has occured
     private final Short2IntMap[] oresPerY = new Short2IntOpenHashMap[VP.minecraftWorldHeight];
+    private final String dimName;
 
-    public DetailedChunkAnalysis(int dimensionId, int chunkX, int chunkZ) {
+    public DetailedChunkAnalysis(int dimensionId, String dimName, int chunkX, int chunkZ) {
         this.dimensionId = dimensionId;
         this.chunkX = chunkX;
         this.chunkZ = chunkZ;
+        this.dimName = dimName;
     }
 
     public void processMinecraftChunk(final NBTTagList tileEntities) {
         if (tileEntities == null || tileEntities.tagCount() == 0) return;
         for (int i = 0; i < tileEntities.tagCount(); i++) {
             final NBTTagCompound tile = tileEntities.getCompoundTagAt(i);
-            if (tile == null || !tile.hasKey("id")) continue;
-            final String tagId = tile.getString("id");
+            if (tile == null || !tile.hasKey("m")) continue;
 
-            if (!tagId.equals("GT_TileEntity_Ores")) {
+            String id = tile.getString("id");
+            if (!"GT_TileEntity_Ores".equals(id) && !"bw.blockoresTE".equals(id)) {
                 continue;
             }
 
@@ -54,10 +56,6 @@ public class DetailedChunkAnalysis {
 
             if (oresPerY[blockY] == null) {
                 oresPerY[blockY] = new Short2IntOpenHashMap();
-            }
-
-            if (!oresPerY[blockY].containsKey(meta)) {
-                oresPerY[blockY].put(meta, 0);
             }
 
             oresPerY[blockY].put(meta, oresPerY[blockY].get(meta) + 1);
@@ -159,7 +157,7 @@ public class DetailedChunkAnalysis {
                 .sorted(Map.Entry.comparingByValue(Comparator.reverseOrder())).map(Map.Entry::getKey).findFirst();
         if (dominantOre.isPresent()) {
             for (VeinType veinType : VeinTypeCaching.veinTypes) {
-                if (veinType.matchesWithSpecificPrimaryOrSecondary(allOres.keySet(), dominantOre.get())) {
+                if (veinType.matchesWithSpecificPrimaryOrSecondary(allOres.keySet(), dimName, dominantOre.get())) {
                     matchedVeins.add(veinType);
                 }
             }

--- a/src/main/java/com/sinthoras/visualprospecting/database/cachebuilder/DetailedChunkAnalysis.java
+++ b/src/main/java/com/sinthoras/visualprospecting/database/cachebuilder/DetailedChunkAnalysis.java
@@ -118,12 +118,14 @@ public class DetailedChunkAnalysis {
         // but that case is rare and therefore, neglected
         for (int neighborId = 0; neighborId < neighbors.length; neighborId++) {
             final OreVeinPosition neighbor = neighbors[neighborId];
+            if (neighbor.veinType == VeinType.NO_VEIN) continue;
+
             final boolean atCoordinateAxis = Math.abs(neighbor.chunkX - chunkX) < 3
                     || Math.abs(neighbor.chunkZ - chunkZ) < 3;
             final boolean canOverlap = atCoordinateAxis
                     ? neighbor.veinType.canOverlapIntoNeighborOreChunkAtCoordinateAxis()
                     : neighbor.veinType.canOverlapIntoNeighborOreChunk();
-            if (neighbor.veinType != VeinType.NO_VEIN && canOverlap) {
+            if (canOverlap) {
                 final int veinBlockY = neighborVeinBlockY[neighborId];
                 for (int layerBlockY = 0; layerBlockY < VeinType.veinHeight; layerBlockY++) {
                     final int blockY = veinBlockY + layerBlockY;
@@ -153,13 +155,15 @@ public class DetailedChunkAnalysis {
             }
         }
 
+        if (allOres.isEmpty()) return VeinType.NO_VEIN;
+
         final Optional<Short> dominantOre = allOres.short2IntEntrySet().stream()
                 .sorted(Map.Entry.comparingByValue(Comparator.reverseOrder())).map(Map.Entry::getKey).findFirst();
-        if (dominantOre.isPresent()) {
-            for (VeinType veinType : VeinTypeCaching.veinTypes) {
-                if (veinType.matchesWithSpecificPrimaryOrSecondary(allOres.keySet(), dimName, dominantOre.get())) {
-                    matchedVeins.add(veinType);
-                }
+        if (!dominantOre.isPresent()) return VeinType.NO_VEIN;
+
+        for (VeinType veinType : VeinTypeCaching.veinTypes) {
+            if (veinType.matchesWithSpecificPrimaryOrSecondary(allOres.keySet(), dimName, dominantOre.get())) {
+                matchedVeins.add(veinType);
             }
         }
 

--- a/src/main/java/com/sinthoras/visualprospecting/database/veintypes/BartworksOreMaterialProvider.java
+++ b/src/main/java/com/sinthoras/visualprospecting/database/veintypes/BartworksOreMaterialProvider.java
@@ -2,9 +2,8 @@ package com.sinthoras.visualprospecting.database.veintypes;
 
 import static bartworks.util.BWColorUtil.getColorFromRGBArray;
 
+import java.util.ArrayList;
 import java.util.List;
-import java.util.Objects;
-import java.util.stream.Collectors;
 
 import net.minecraft.util.EnumChatFormatting;
 import net.minecraft.util.IIcon;
@@ -12,6 +11,7 @@ import net.minecraft.util.IIcon;
 import bartworks.system.material.Werkstoff;
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
+import gregtech.api.GregTechAPI;
 import gregtech.api.enums.OrePrefixes;
 import it.unimi.dsi.fastutil.shorts.ShortCollection;
 
@@ -49,8 +49,16 @@ public class BartworksOreMaterialProvider implements IOreMaterialProvider {
 
     @Override
     public List<String> getContainedOres(ShortCollection ores) {
-        return ores.intStream().mapToObj(metaData -> Werkstoff.werkstoffHashMap.get((short) metaData))
-                .filter(Objects::nonNull).map(material -> EnumChatFormatting.GRAY + material.getLocalizedName())
-                .collect(Collectors.toList());
+        List<String> oreNames = new ArrayList<>();
+        for (short meta : ores) {
+            Werkstoff werkstoff = Werkstoff.werkstoffHashMap.get(meta);
+            if (werkstoff == null) {
+                oreNames.add(EnumChatFormatting.GRAY + GregTechAPI.sGeneratedMaterials[meta].mLocalizedName);
+            } else {
+                oreNames.add(EnumChatFormatting.GRAY + werkstoff.getLocalizedName());
+
+            }
+        }
+        return oreNames;
     }
 }

--- a/src/main/java/com/sinthoras/visualprospecting/database/veintypes/BartworksOreMaterialProvider.java
+++ b/src/main/java/com/sinthoras/visualprospecting/database/veintypes/BartworksOreMaterialProvider.java
@@ -7,6 +7,8 @@ import java.util.List;
 
 import net.minecraft.util.IIcon;
 
+import com.google.common.collect.ImmutableList;
+
 import bartworks.system.material.Werkstoff;
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
@@ -20,6 +22,7 @@ public class BartworksOreMaterialProvider implements IOreMaterialProvider {
     private final int primaryOreColor;
     private final String primaryOreName;
     private IIcon primaryOreIcon;
+    private ImmutableList<String> containedOres;
 
     public BartworksOreMaterialProvider(Werkstoff material) {
         this.material = material;
@@ -47,17 +50,20 @@ public class BartworksOreMaterialProvider implements IOreMaterialProvider {
     }
 
     @Override
-    public List<String> getContainedOres(ShortCollection ores) {
-        List<String> oreNames = new ArrayList<>();
-        for (short meta : ores) {
-            Werkstoff werkstoff = Werkstoff.werkstoffHashMap.get(meta);
-            if (werkstoff == null) {
-                oreNames.add(GregTechAPI.sGeneratedMaterials[meta].mLocalizedName);
-            } else {
-                oreNames.add(werkstoff.getLocalizedName());
+    public ImmutableList<String> getContainedOres(ShortCollection ores) {
+        if (containedOres == null) {
+            List<String> oreNames = new ArrayList<>();
+            for (short meta : ores) {
+                Werkstoff werkstoff = Werkstoff.werkstoffHashMap.get(meta);
+                if (werkstoff == null) {
+                    oreNames.add(GregTechAPI.sGeneratedMaterials[meta].mLocalizedName);
+                } else {
+                    oreNames.add(werkstoff.getLocalizedName());
 
+                }
             }
+            containedOres = ImmutableList.copyOf(oreNames);
         }
-        return oreNames;
+        return containedOres;
     }
 }

--- a/src/main/java/com/sinthoras/visualprospecting/database/veintypes/BartworksOreMaterialProvider.java
+++ b/src/main/java/com/sinthoras/visualprospecting/database/veintypes/BartworksOreMaterialProvider.java
@@ -5,7 +5,6 @@ import static bartworks.util.BWColorUtil.getColorFromRGBArray;
 import java.util.ArrayList;
 import java.util.List;
 
-import net.minecraft.util.EnumChatFormatting;
 import net.minecraft.util.IIcon;
 
 import bartworks.system.material.Werkstoff;
@@ -53,9 +52,9 @@ public class BartworksOreMaterialProvider implements IOreMaterialProvider {
         for (short meta : ores) {
             Werkstoff werkstoff = Werkstoff.werkstoffHashMap.get(meta);
             if (werkstoff == null) {
-                oreNames.add(EnumChatFormatting.GRAY + GregTechAPI.sGeneratedMaterials[meta].mLocalizedName);
+                oreNames.add(GregTechAPI.sGeneratedMaterials[meta].mLocalizedName);
             } else {
-                oreNames.add(EnumChatFormatting.GRAY + werkstoff.getLocalizedName());
+                oreNames.add(werkstoff.getLocalizedName());
 
             }
         }

--- a/src/main/java/com/sinthoras/visualprospecting/database/veintypes/GregTechOreMaterialProvider.java
+++ b/src/main/java/com/sinthoras/visualprospecting/database/veintypes/GregTechOreMaterialProvider.java
@@ -1,10 +1,11 @@
 package com.sinthoras.visualprospecting.database.veintypes;
 
+import java.util.ArrayList;
 import java.util.List;
-import java.util.Objects;
-import java.util.stream.Collectors;
 
 import net.minecraft.util.IIcon;
+
+import com.google.common.collect.ImmutableList;
 
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
@@ -19,11 +20,19 @@ public class GregTechOreMaterialProvider implements IOreMaterialProvider {
     private final int primaryOreColor;
     private IIcon primaryOreIcon;
     private final String primaryOreName;
+    private ImmutableList<String> containedOres;
 
     public GregTechOreMaterialProvider(Materials material) {
         this.material = material;
         this.primaryOreColor = (material.mRGBa[0] << 16) | (material.mRGBa[1]) << 8 | material.mRGBa[2];
         this.primaryOreName = material.mLocalizedName;
+    }
+
+    GregTechOreMaterialProvider() {
+        material = Materials._NULL;
+        primaryOreColor = 0;
+        primaryOreName = "";
+        containedOres = ImmutableList.of();
     }
 
     @Override
@@ -46,8 +55,16 @@ public class GregTechOreMaterialProvider implements IOreMaterialProvider {
     }
 
     @Override
-    public List<String> getContainedOres(ShortCollection ores) {
-        return ores.intStream().mapToObj(metaData -> GregTechAPI.sGeneratedMaterials[metaData]).filter(Objects::nonNull)
-                .map(material -> material.mLocalizedName).collect(Collectors.toList());
+    public ImmutableList<String> getContainedOres(ShortCollection ores) {
+        if (containedOres == null) {
+            List<String> temp = new ArrayList<>();
+            for (short meta : ores) {
+                Materials material = GregTechAPI.sGeneratedMaterials[meta];
+                if (material == null) continue;
+                temp.add(material.mLocalizedName);
+            }
+            containedOres = ImmutableList.copyOf(temp);
+        }
+        return containedOres;
     }
 }

--- a/src/main/java/com/sinthoras/visualprospecting/database/veintypes/GregTechOreMaterialProvider.java
+++ b/src/main/java/com/sinthoras/visualprospecting/database/veintypes/GregTechOreMaterialProvider.java
@@ -4,7 +4,6 @@ import java.util.List;
 import java.util.Objects;
 import java.util.stream.Collectors;
 
-import net.minecraft.util.EnumChatFormatting;
 import net.minecraft.util.IIcon;
 
 import cpw.mods.fml.relauncher.Side;
@@ -49,6 +48,6 @@ public class GregTechOreMaterialProvider implements IOreMaterialProvider {
     @Override
     public List<String> getContainedOres(ShortCollection ores) {
         return ores.intStream().mapToObj(metaData -> GregTechAPI.sGeneratedMaterials[metaData]).filter(Objects::nonNull)
-                .map(material -> EnumChatFormatting.GRAY + material.mLocalizedName).collect(Collectors.toList());
+                .map(material -> material.mLocalizedName).collect(Collectors.toList());
     }
 }

--- a/src/main/java/com/sinthoras/visualprospecting/database/veintypes/IOreMaterialProvider.java
+++ b/src/main/java/com/sinthoras/visualprospecting/database/veintypes/IOreMaterialProvider.java
@@ -1,8 +1,8 @@
 package com.sinthoras.visualprospecting.database.veintypes;
 
-import java.util.List;
-
 import net.minecraft.util.IIcon;
+
+import com.google.common.collect.ImmutableList;
 
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
@@ -17,5 +17,5 @@ public interface IOreMaterialProvider {
 
     String getLocalizedName();
 
-    List<String> getContainedOres(ShortCollection ores);
+    ImmutableList<String> getContainedOres(ShortCollection ores);
 }

--- a/src/main/java/com/sinthoras/visualprospecting/database/veintypes/VeinType.java
+++ b/src/main/java/com/sinthoras/visualprospecting/database/veintypes/VeinType.java
@@ -6,6 +6,7 @@ import java.util.List;
 import com.sinthoras.visualprospecting.Tags;
 
 import gregtech.common.OreMixBuilder;
+import it.unimi.dsi.fastutil.shorts.ShortArraySet;
 import it.unimi.dsi.fastutil.shorts.ShortCollection;
 import it.unimi.dsi.fastutil.shorts.ShortOpenHashSet;
 import it.unimi.dsi.fastutil.shorts.ShortSet;
@@ -24,7 +25,7 @@ public class VeinType {
     public final short sporadicOreMeta;
     public final int minBlockY;
     public final int maxBlockY;
-    public final ShortSet oresAsSet = new ShortOpenHashSet();
+    public final ShortSet oresAsSet = new ShortArraySet();
     private final List<String> containedOres = new ArrayList<>();
     private boolean isHighlighted = true;
     private String primaryOreName = "";

--- a/src/main/java/com/sinthoras/visualprospecting/database/veintypes/VeinType.java
+++ b/src/main/java/com/sinthoras/visualprospecting/database/veintypes/VeinType.java
@@ -77,8 +77,8 @@ public class VeinType {
         allowedDims.addAll(oreMix.dimsEnabled.keySet());
     }
 
-    public boolean containsAllFoundOres(ShortCollection foundOres, String dimName, short specificMeta) {
-        return (primaryOreMeta == specificMeta || secondaryOreMeta == specificMeta)
+    public boolean containsAllFoundOres(ShortCollection foundOres, String dimName, short specificMeta, int minY) {
+        return minY >= minBlockY && (primaryOreMeta == specificMeta || secondaryOreMeta == specificMeta)
                 && (dimName.isEmpty() || allowedDims.contains(dimName))
                 && oresAsSet.containsAll(foundOres);
     }

--- a/src/main/java/com/sinthoras/visualprospecting/database/veintypes/VeinType.java
+++ b/src/main/java/com/sinthoras/visualprospecting/database/veintypes/VeinType.java
@@ -3,6 +3,9 @@ package com.sinthoras.visualprospecting.database.veintypes;
 import java.util.ArrayList;
 import java.util.List;
 
+import javax.annotation.ParametersAreNonnullByDefault;
+
+import com.google.common.collect.ImmutableList;
 import com.sinthoras.visualprospecting.Tags;
 
 import gregtech.common.OreMixBuilder;
@@ -11,6 +14,7 @@ import it.unimi.dsi.fastutil.shorts.ShortCollection;
 import it.unimi.dsi.fastutil.shorts.ShortOpenHashSet;
 import it.unimi.dsi.fastutil.shorts.ShortSet;
 
+@ParametersAreNonnullByDefault
 public class VeinType {
 
     public static final int veinHeight = 9;
@@ -25,16 +29,14 @@ public class VeinType {
     public final short sporadicOreMeta;
     public final int minBlockY;
     public final int maxBlockY;
-    public final ShortSet oresAsSet = new ShortArraySet();
-    private final List<String> containedOres = new ArrayList<>();
-    private boolean isHighlighted = true;
-    private String primaryOreName = "";
+    private final ShortSet oresAsSet = new ShortArraySet();
     private final List<String> allowedDims = new ArrayList<>();
+    private boolean isHighlighted = true;
 
     // Available after VisualProspecting post GT initialization
     public static final VeinType NO_VEIN = new VeinType(
             Tags.ORE_MIX_NONE_NAME,
-            null,
+            new GregTechOreMaterialProvider(),
             0,
             (short) -1,
             (short) -1,
@@ -57,10 +59,6 @@ public class VeinType {
         oresAsSet.add(this.inBetweenOreMeta = inBetweenOreMeta);
         oresAsSet.add(this.sporadicOreMeta = sporadicOreMeta);
         allowedDims.add(dimName);
-        if (oreMaterialProvider != null) {
-            containedOres.addAll(oreMaterialProvider.getContainedOres(oresAsSet));
-            primaryOreName = oreMaterialProvider.getLocalizedName();
-        }
     }
 
     public VeinType(OreMixBuilder oreMix) {
@@ -73,8 +71,6 @@ public class VeinType {
         oresAsSet.add(sporadicOreMeta = (short) oreMix.sporadic.mMetaItemSubID);
         minBlockY = Math.max(0, oreMix.minY - 6);
         maxBlockY = Math.min(255, oreMix.maxY - 6);
-        containedOres.addAll(oreMaterialProvider.getContainedOres(oresAsSet));
-        primaryOreName = oreMaterialProvider.getLocalizedName();
         allowedDims.addAll(oreMix.dimsEnabled.keySet());
     }
 
@@ -106,12 +102,12 @@ public class VeinType {
                 || sporadicOreMeta == oreMetaData;
     }
 
-    public List<String> getOreMaterialNames() {
-        return containedOres;
+    public ImmutableList<String> getOreMaterialNames() {
+        return oreMaterialProvider.getContainedOres(oresAsSet);
     }
 
     public String getPrimaryOreName() {
-        return primaryOreName;
+        return oreMaterialProvider.getLocalizedName();
     }
 
     public ShortSet getOresAtLayer(int layerBlockY) {
@@ -152,7 +148,7 @@ public class VeinType {
         return isHighlighted;
     }
 
-    public void setNEISearchHeighlight(boolean isHighlighted) {
+    public void setNEISearchHighlight(boolean isHighlighted) {
         this.isHighlighted = isHighlighted;
     }
 }

--- a/src/main/java/com/sinthoras/visualprospecting/database/veintypes/VeinTypeCaching.java
+++ b/src/main/java/com/sinthoras/visualprospecting/database/veintypes/VeinTypeCaching.java
@@ -127,14 +127,13 @@ public class VeinTypeCaching implements Runnable {
                 if (veinType == VeinType.NO_VEIN) continue;
                 if (isSearchActive && !searchString.isEmpty()) {
                     List<String> searchableStrings = veinType.getOreMaterialNames();
-                    searchableStrings.add(veinType.getPrimaryOreName());
                     final boolean match = searchableStrings.stream()
                             .map(EnumChatFormatting::getTextWithoutFormattingCodes).map(String::toLowerCase)
                             .anyMatch(searchableString -> filterPattern.matcher(searchableString).find());
 
-                    veinType.setNEISearchHeighlight(match);
+                    veinType.setNEISearchHighlight(match);
                 } else {
-                    veinType.setNEISearchHeighlight(true);
+                    veinType.setNEISearchHighlight(true);
                 }
             }
         }

--- a/src/main/java/com/sinthoras/visualprospecting/database/veintypes/VeinTypeCaching.java
+++ b/src/main/java/com/sinthoras/visualprospecting/database/veintypes/VeinTypeCaching.java
@@ -23,7 +23,6 @@ import codechicken.nei.SearchField;
 import gregtech.api.GregTechAPI;
 import gregtech.api.enums.Materials;
 import gregtech.api.enums.OreMixes;
-import gregtech.common.OreMixBuilder;
 import it.unimi.dsi.fastutil.objects.Object2ShortMap;
 import it.unimi.dsi.fastutil.objects.Object2ShortOpenHashMap;
 import it.unimi.dsi.fastutil.objects.ObjectOpenHashSet;
@@ -46,9 +45,7 @@ public class VeinTypeCaching implements Runnable {
         veinTypes.add(VeinType.NO_VEIN);
 
         for (OreMixes mix : OreMixes.values()) {
-            OreMixBuilder builder = mix.oreMixBuilder;
-            VeinType vein = new VeinType(builder);
-            veinTypes.add(vein);
+            veinTypes.add(new VeinType(mix.oreMixBuilder));
         }
 
         for (BWOreLayer vein : BWOreLayer.sList) {

--- a/src/main/java/com/sinthoras/visualprospecting/database/veintypes/VeinTypeCaching.java
+++ b/src/main/java/com/sinthoras/visualprospecting/database/veintypes/VeinTypeCaching.java
@@ -11,8 +11,6 @@ import java.util.regex.Pattern;
 
 import net.minecraft.util.EnumChatFormatting;
 
-import com.google.common.collect.BiMap;
-import com.google.common.collect.HashBiMap;
 import com.sinthoras.visualprospecting.Tags;
 import com.sinthoras.visualprospecting.Utils;
 
@@ -27,10 +25,12 @@ import it.unimi.dsi.fastutil.objects.Object2ShortMap;
 import it.unimi.dsi.fastutil.objects.Object2ShortOpenHashMap;
 import it.unimi.dsi.fastutil.objects.ObjectOpenHashSet;
 import it.unimi.dsi.fastutil.objects.ObjectSet;
+import it.unimi.dsi.fastutil.shorts.Short2ObjectMap;
+import it.unimi.dsi.fastutil.shorts.Short2ObjectOpenHashMap;
 
 public class VeinTypeCaching implements Runnable {
 
-    private static final BiMap<Short, VeinType> veinTypeLookupTableForIds = HashBiMap.create();
+    private static final Short2ObjectMap<VeinType> veinTypeLookupTableForIds = new Short2ObjectOpenHashMap<>();
     private static final Map<String, VeinType> veinTypeLookupTableForNames = new HashMap<>();
     private static final Object2ShortMap<String> veinTypeStorageInfo = new Object2ShortOpenHashMap<>();
     public static ObjectSet<VeinType> veinTypes;
@@ -85,13 +85,10 @@ public class VeinTypeCaching implements Runnable {
         final Materials material = GregTechAPI.sGeneratedMaterials[metaId];
         if (material == null) {
             // Some materials are not registered in dev when their usage mod is not available.
-            return Materials.getAll().stream().filter(m -> m.mMetaItemSubID == metaId).findAny().get();
+            return Materials.getAll().stream().filter(m -> m.mMetaItemSubID == metaId).findAny()
+                    .orElse(Materials._NULL);
         }
         return material;
-    }
-
-    public static short getVeinTypeId(VeinType veinType) {
-        return veinTypeLookupTableForIds.inverse().get(veinType);
     }
 
     public static VeinType getVeinType(short veinTypeId) {

--- a/src/main/java/com/sinthoras/visualprospecting/database/veintypes/VeinTypeCaching.java
+++ b/src/main/java/com/sinthoras/visualprospecting/database/veintypes/VeinTypeCaching.java
@@ -9,7 +9,6 @@ import java.util.Map;
 import java.util.OptionalInt;
 import java.util.regex.Pattern;
 
-import net.minecraft.client.resources.I18n;
 import net.minecraft.util.EnumChatFormatting;
 
 import com.google.common.collect.BiMap;
@@ -163,7 +162,7 @@ public class VeinTypeCaching implements Runnable {
                 if (veinType == VeinType.NO_VEIN) continue;
                 if (isSearchActive && !searchString.isEmpty()) {
                     List<String> searchableStrings = veinType.getOreMaterialNames();
-                    searchableStrings.add(I18n.format(veinType.name));
+                    searchableStrings.add(veinType.getPrimaryOreName());
                     final boolean match = searchableStrings.stream()
                             .map(EnumChatFormatting::getTextWithoutFormattingCodes).map(String::toLowerCase)
                             .anyMatch(searchableString -> filterPattern.matcher(searchableString).find());

--- a/src/main/java/com/sinthoras/visualprospecting/integration/model/locations/OreVeinLocation.java
+++ b/src/main/java/com/sinthoras/visualprospecting/integration/model/locations/OreVeinLocation.java
@@ -43,7 +43,7 @@ public class OreVeinLocation implements IWaypointAndLocationProvider {
                 65,
                 oreVeinPosition.getBlockZ(),
                 oreVeinPosition.dimensionId,
-                I18n.format("visualprospecting.tracked", I18n.format(oreVeinPosition.veinType.name)),
+                I18n.format("visualprospecting.tracked", oreVeinPosition.veinType.getPrimaryOreName()),
                 getColor());
     }
 

--- a/src/main/java/com/sinthoras/visualprospecting/integration/voxelmap/VoxelMapEventHandler.java
+++ b/src/main/java/com/sinthoras/visualprospecting/integration/voxelmap/VoxelMapEventHandler.java
@@ -5,7 +5,6 @@ import java.util.TreeSet;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.entity.EntityClientPlayerMP;
 import net.minecraft.item.ItemStack;
-import net.minecraft.util.StatCollector;
 
 import com.gtnewhorizons.navigator.api.voxelmap.VoxelMapWaypointManager;
 import com.sinthoras.visualprospecting.Config;
@@ -30,7 +29,7 @@ public class VoxelMapEventHandler {
         TreeSet<Integer> dim = new TreeSet<>();
         dim.add(pos.dimensionId);
         VoxelMapWaypointManager.addVoxelMapWaypoint(
-                StatCollector.translateToLocal(pos.veinType.name), // name
+                pos.veinType.getPrimaryOreName(), // name
                 pos.getBlockX(), // X
                 pos.getBlockZ(), // Z
                 getY(), // Y


### PR DESCRIPTION
Most importantly this fixes only newly discovered veins being saved, it worked perfectly fine when migrating from the old cache but it would all be overwritten as soon as a new vein was discovered. (oops)

Some of the chunk analysis changes I made in #54 were missing far too many veins, it has been changed to something closer to what it was previously with some added checks for whether the primary meta matches & if ore can spawn in a given dimension (if it exists)
This is slightly slower but has a significantly lower miss rate, in a sample of ~11400 ore chunks only 178 were missed/couldn't be identified during the first pass and the vast majority of them were correctly identified in the second pass. 

Okay I also got a larger sample size for shits and giggles:
43674 total ore veins of which
1968 had to be identified in second pass 
351 failed to be identified (most are probably too high/low y level or just didn't spawn)
This means that 95.5% were correctly identified in the first pass and only 0.8% failed to be identified
