### PR TITLE
Fix veins differing between server and clients

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -1,7 +1,7 @@
 dependencies {
     api('com.github.GTNewHorizons:Navigator:1.0.12:dev')
     api('com.github.GTNewHorizons:GTNHLib:0.5.11:dev')
-    api('com.github.GTNewHorizons:GT5-Unofficial:5.09.50.01:dev')
+    api('com.github.GTNewHorizons:GT5-Unofficial:5.09.50.06:dev')
 
     runtimeOnlyNonPublishable(rfg.deobf('maven.modrinth:journeymap:5.2.6'))
 }

--- a/src/main/java/com/sinthoras/visualprospecting/utils/VPByteBufUtils.java
+++ b/src/main/java/com/sinthoras/visualprospecting/utils/VPByteBufUtils.java
@@ -11,6 +11,7 @@ import com.sinthoras.visualprospecting.database.OreVeinPosition;
 import com.sinthoras.visualprospecting.database.UndergroundFluidPosition;
 import com.sinthoras.visualprospecting.database.veintypes.VeinTypeCaching;
 
+import cpw.mods.fml.common.network.ByteBufUtils;
 import io.netty.buffer.ByteBuf;
 
 public final class VPByteBufUtils {
@@ -19,18 +20,18 @@ public final class VPByteBufUtils {
         buf.writeInt(oreVeinPosition.dimensionId);
         buf.writeInt(oreVeinPosition.chunkX);
         buf.writeInt(oreVeinPosition.chunkZ);
-        buf.writeShort(oreVeinPosition.veinType.veinId);
         buf.writeBoolean(oreVeinPosition.isDepleted());
+        ByteBufUtils.writeUTF8String(buf, oreVeinPosition.veinType.name);
     }
 
     public static OreVeinPosition ReadOreVeinPosition(ByteBuf buf) {
         final int dimId = buf.readInt();
         final int chunkX = buf.readInt();
         final int chunkZ = buf.readInt();
-        final short veinId = buf.readShort();
         final boolean isDepleted = buf.readBoolean();
+        final String veinName = ByteBufUtils.readUTF8String(buf);
 
-        return new OreVeinPosition(dimId, chunkX, chunkZ, VeinTypeCaching.getVeinType(veinId), isDepleted);
+        return new OreVeinPosition(dimId, chunkX, chunkZ, VeinTypeCaching.getVeinType(veinName), isDepleted);
     }
 
     public static void WriteUndergroundFluidPosition(ByteBuf buf, UndergroundFluidPosition undergroundFluidPosition) {


### PR DESCRIPTION
Fixes https://discord.com/channels/181078474394566657/522098956491030558/1286984717304074354

The changes made to vein caching [here](https://github.com/GTNewHorizons/VisualProspecting/pull/55/commits/48e141f54c5e42ea73a841942060ae4a89d38024#diff-d109f467031bffc40b016f16a95873065744189411fdce8fae6bdfe7429fa784) caused the id's that veins get assigned to differ between old and newly generated caches.
To prevent any future mishaps we just send the vein name in the prospecting packet instead which can't ever differ between server & client.

Confirmed working https://discord.com/channels/181078474394566657/522098956491030558/1287024258391871518

Closes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/17412