### PR TITLE
add NEI hotkeys support when mouse over ore vein

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -1,5 +1,5 @@
 dependencies {
-    api('com.github.GTNewHorizons:Navigator:1.0.12:dev')
+    api('com.github.GTNewHorizons:Navigator:1.0.13:dev')
     api('com.github.GTNewHorizons:GTNHLib:0.5.11:dev')
     api('com.github.GTNewHorizons:GT5-Unofficial:5.09.50.09:dev')
 

--- a/src/main/java/com/sinthoras/visualprospecting/integration/model/locations/OreVeinLocation.java
+++ b/src/main/java/com/sinthoras/visualprospecting/integration/model/locations/OreVeinLocation.java
@@ -118,4 +118,8 @@ public class OreVeinLocation implements IWaypointAndLocationProvider {
     public IIcon getIconFromPrimaryOre() {
         return oreVeinPosition.veinType.oreMaterialProvider.getIcon();
     }
+
+    public short getPrimaryOreMeta() {
+        return oreVeinPosition.veinType.primaryOreMeta;
+    }
 }

--- a/src/main/java/com/sinthoras/visualprospecting/integration/model/render/OreVeinRenderStep.java
+++ b/src/main/java/com/sinthoras/visualprospecting/integration/model/render/OreVeinRenderStep.java
@@ -3,7 +3,9 @@ package com.sinthoras.visualprospecting.integration.model.render;
 import java.util.List;
 
 import net.minecraft.client.Minecraft;
+import net.minecraft.client.audio.PositionedSoundRecord;
 import net.minecraft.init.Blocks;
+import net.minecraft.item.ItemStack;
 import net.minecraft.util.IIcon;
 import net.minecraft.util.ResourceLocation;
 
@@ -13,8 +15,12 @@ import com.sinthoras.visualprospecting.Config;
 import com.sinthoras.visualprospecting.Tags;
 import com.sinthoras.visualprospecting.integration.model.locations.OreVeinLocation;
 
+import codechicken.nei.api.ShortcutInputHandler;
+import gregtech.api.GregTechAPI;
+
 public class OreVeinRenderStep extends UniversalInteractableStep<OreVeinLocation> {
 
+    private static final ResourceLocation clickSound = new ResourceLocation("gui.button.press");
     private static final ResourceLocation depletedTextureLocation = new ResourceLocation(
             Tags.MODID,
             "textures/depleted.png");
@@ -90,4 +96,23 @@ public class OreVeinRenderStep extends UniversalInteractableStep<OreVeinLocation
         location.toggleOreVein();
     }
 
+    @Override
+    public boolean onKeyPressed(int keyCode) {
+
+        if (super.onKeyPressed(keyCode)) {
+            return true;
+        }
+
+        final var itemStack = new ItemStack(GregTechAPI.sBlockOres1, 1, location.getPrimaryOreMeta());
+        if (ShortcutInputHandler.handleKeyEvent(itemStack)) {
+            playClickSound();
+            return true;
+        }
+
+        return false;
+    }
+
+    private void playClickSound() {
+        Minecraft.getMinecraft().getSoundHandler().playSound(PositionedSoundRecord.func_147674_a(clickSound, 1.0F));
+    }
 }


### PR DESCRIPTION
Add NEI hotkeys support when mouse over ore vein.

Also added click sound like in [BetterQuesting](https://github.com/GTNewHorizons/BetterQuesting/blob/36094122a6c19919af8ea0c4c7da9a4d5d024cbc/src/main/java/bq_standard/client/gui/panels/content/PanelInteractiveItemSlot.java#L32). For example, without sound there is no feedback, when pressing hotkey A.

Required Navigator 1.0.13.