### PR TITLE
Yet another fix for !visualprospectingnearspawn

### DIFF
--- a/src/main/java/com/sinthoras/visualprospecting/VP.java
+++ b/src/main/java/com/sinthoras/visualprospecting/VP.java
@@ -12,7 +12,7 @@ public class VP {
     public static SimpleNetworkWrapper network;
     public static final Random randomGeneration = new Random();
 
-    private static Logger LOG = LogManager.getLogger(Tags.MODID);
+    public static final Logger LOG = LogManager.getLogger(Tags.MODID);
     public static final int gregTechSmallOreMinimumMeta = 16000;
     public static final int minecraftWorldHeight = 256;
     public static final int chunksPerRegionFileX = 32;


### PR DESCRIPTION
It was running a re-cache, which clears the current cache, if no cache files existed in the VP folder and those files won't exist until the world saves. Skipping that step for new worlds has completely removed the problem.