### PR TITLE
Fix client cache being removed after changing username

### DIFF
--- a/src/main/java/com/sinthoras/visualprospecting/database/ClientCache.java
+++ b/src/main/java/com/sinthoras/visualprospecting/database/ClientCache.java
@@ -29,9 +29,19 @@ public class ClientCache extends WorldCache {
 
     protected File getStorageDirectory() {
         final EntityClientPlayerMP player = Minecraft.getMinecraft().thePlayer;
-        return new File(
-                Utils.getSubDirectory(Tags.CLIENT_DIR),
+        File oldCacheDir = new File(
+                Tags.CLIENT_DIR,
                 player.getDisplayName() + "_" + player.getPersistentID().toString());
+        File newCacheDir = new File(Tags.CLIENT_DIR, player.getPersistentID().toString());
+        if (oldCacheDir.exists()) {
+            if (oldCacheDir.renameTo(newCacheDir)) {
+                return newCacheDir;
+            }
+            // Something went wrong, just return the old cache directory
+            return oldCacheDir;
+        }
+
+        return newCacheDir;
     }
 
     private void notifyNewOreVein(OreVeinPosition oreVeinPosition) {

--- a/src/main/java/com/sinthoras/visualprospecting/database/ClientCache.java
+++ b/src/main/java/com/sinthoras/visualprospecting/database/ClientCache.java
@@ -1,6 +1,7 @@
 package com.sinthoras.visualprospecting.database;
 
 import java.io.File;
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -13,6 +14,8 @@ import net.minecraft.util.EnumChatFormatting;
 import net.minecraft.util.IChatComponent;
 import net.minecraft.world.World;
 import net.minecraftforge.common.MinecraftForge;
+
+import org.apache.commons.io.FileUtils;
 
 import com.sinthoras.visualprospecting.Config;
 import com.sinthoras.visualprospecting.Tags;
@@ -34,11 +37,7 @@ public class ClientCache extends WorldCache {
                 player.getDisplayName() + "_" + player.getPersistentID().toString());
         File newCacheDir = new File(Tags.CLIENT_DIR, player.getPersistentID().toString());
         if (oldCacheDir.exists()) {
-            if (oldCacheDir.renameTo(newCacheDir)) {
-                return newCacheDir;
-            }
-            // Something went wrong, just return the old cache directory
-            return oldCacheDir;
+            convertOldCache(oldCacheDir, newCacheDir);
         }
 
         return newCacheDir;
@@ -173,5 +172,22 @@ public class ClientCache extends WorldCache {
             allUndergroundFluids.addAll(dimension.getAllUndergroundFluids());
         }
         return allUndergroundFluids;
+    }
+
+    private static void convertOldCache(File oldCache, File newCache) {
+        if (!oldCache.exists()) return;
+        File[] files = oldCache.listFiles();
+        if (files != null && files.length > 0 && newCache.exists()) {
+            for (File file : files) {
+                if (!file.isDirectory()) continue;
+                try {
+                    FileUtils.copyDirectoryToDirectory(file, newCache);
+                } catch (IOException ignored) {}
+            }
+            Utils.deleteDirectoryRecursively(oldCache);
+        } else {
+            // noinspection ResultOfMethodCallIgnored
+            oldCache.renameTo(newCache);
+        }
     }
 }


### PR DESCRIPTION
The cherry on top is that it's using the player display name, so setting a nickname would likewise cause it to use a different cache directory.. (At least in SP)

Closes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/17500