### PR TITLE
upd(render): add support for ore icon overlay

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -1,7 +1,7 @@
 dependencies {
     api('com.github.GTNewHorizons:Navigator:1.0.16:dev')
     api('com.github.GTNewHorizons:GTNHLib:0.6.37:dev')
-    api('com.github.GTNewHorizons:GT5-Unofficial:5.09.51.388:dev')
+    api('com.github.GTNewHorizons:GT5-Unofficial:5.09.51.422:dev')
 
     runtimeOnlyNonPublishable(rfg.deobf('maven.modrinth:journeymap:5.2.6'))
 }

--- a/src/main/java/com/sinthoras/visualprospecting/database/veintypes/BartworksOreMaterialProvider.java
+++ b/src/main/java/com/sinthoras/visualprospecting/database/veintypes/BartworksOreMaterialProvider.java
@@ -3,8 +3,6 @@ package com.sinthoras.visualprospecting.database.veintypes;
 import java.util.ArrayList;
 import java.util.List;
 
-import net.minecraft.util.IIcon;
-
 import com.google.common.collect.ImmutableList;
 
 import bartworks.system.material.Werkstoff;
@@ -12,6 +10,7 @@ import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
 import gregtech.api.GregTechAPI;
 import gregtech.api.enums.OrePrefixes;
+import gregtech.api.interfaces.IIconContainer;
 import it.unimi.dsi.fastutil.shorts.ShortCollection;
 
 public class BartworksOreMaterialProvider implements IOreMaterialProvider {
@@ -19,7 +18,7 @@ public class BartworksOreMaterialProvider implements IOreMaterialProvider {
     private final Werkstoff material;
     private final int primaryOreColor;
     private final String primaryOreName;
-    private IIcon primaryOreIcon;
+    private IIconContainer oreIconContainer;
     private ImmutableList<String> containedOres;
 
     public BartworksOreMaterialProvider(Werkstoff material) {
@@ -31,11 +30,11 @@ public class BartworksOreMaterialProvider implements IOreMaterialProvider {
 
     @Override
     @SideOnly(Side.CLIENT)
-    public IIcon getIcon() {
-        if (primaryOreIcon == null) {
-            primaryOreIcon = material.getTexSet().mTextures[OrePrefixes.ore.mTextureIndex].getIcon();
+    public IIconContainer getIconContainer() {
+        if (oreIconContainer == null) {
+            oreIconContainer = material.getTexSet().mTextures[OrePrefixes.ore.mTextureIndex];
         }
-        return primaryOreIcon;
+        return oreIconContainer;
     }
 
     @Override

--- a/src/main/java/com/sinthoras/visualprospecting/database/veintypes/GregTechOreMaterialProvider.java
+++ b/src/main/java/com/sinthoras/visualprospecting/database/veintypes/GregTechOreMaterialProvider.java
@@ -3,8 +3,6 @@ package com.sinthoras.visualprospecting.database.veintypes;
 import java.util.ArrayList;
 import java.util.List;
 
-import net.minecraft.util.IIcon;
-
 import com.google.common.collect.ImmutableList;
 
 import cpw.mods.fml.relauncher.Side;
@@ -12,13 +10,14 @@ import cpw.mods.fml.relauncher.SideOnly;
 import gregtech.api.GregTechAPI;
 import gregtech.api.enums.Materials;
 import gregtech.api.enums.OrePrefixes;
+import gregtech.api.interfaces.IIconContainer;
 import it.unimi.dsi.fastutil.shorts.ShortCollection;
 
 public class GregTechOreMaterialProvider implements IOreMaterialProvider {
 
     private final Materials material;
     private final int primaryOreColor;
-    private IIcon primaryOreIcon;
+    private IIconContainer oreIconContainer;
     private final String primaryOreName;
     private ImmutableList<String> containedOres;
 
@@ -30,11 +29,11 @@ public class GregTechOreMaterialProvider implements IOreMaterialProvider {
 
     @Override
     @SideOnly(Side.CLIENT)
-    public IIcon getIcon() {
-        if (primaryOreIcon == null) {
-            primaryOreIcon = material.mIconSet.mTextures[OrePrefixes.ore.mTextureIndex].getIcon();
+    public IIconContainer getIconContainer() {
+        if (oreIconContainer == null) {
+            oreIconContainer = material.mIconSet.mTextures[OrePrefixes.ore.mTextureIndex];
         }
-        return primaryOreIcon;
+        return oreIconContainer;
     }
 
     @Override

--- a/src/main/java/com/sinthoras/visualprospecting/database/veintypes/IOreMaterialProvider.java
+++ b/src/main/java/com/sinthoras/visualprospecting/database/veintypes/IOreMaterialProvider.java
@@ -1,17 +1,16 @@
 package com.sinthoras.visualprospecting.database.veintypes;
 
-import net.minecraft.util.IIcon;
-
 import com.google.common.collect.ImmutableList;
 
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
+import gregtech.api.interfaces.IIconContainer;
 import it.unimi.dsi.fastutil.shorts.ShortCollection;
 
 public interface IOreMaterialProvider {
 
     @SideOnly(Side.CLIENT)
-    IIcon getIcon();
+    IIconContainer getIconContainer();
 
     int getColor();
 

--- a/src/main/java/com/sinthoras/visualprospecting/integration/model/locations/OreVeinLocation.java
+++ b/src/main/java/com/sinthoras/visualprospecting/integration/model/locations/OreVeinLocation.java
@@ -5,7 +5,6 @@ import java.util.stream.Collectors;
 
 import net.minecraft.client.resources.I18n;
 import net.minecraft.util.EnumChatFormatting;
-import net.minecraft.util.IIcon;
 
 import org.lwjgl.input.Keyboard;
 
@@ -14,6 +13,8 @@ import com.gtnewhorizons.navigator.api.model.locations.IWaypointAndLocationProvi
 import com.gtnewhorizons.navigator.api.model.waypoints.Waypoint;
 import com.sinthoras.visualprospecting.database.ClientCache;
 import com.sinthoras.visualprospecting.database.OreVeinPosition;
+
+import gregtech.api.interfaces.IIconContainer;
 
 public class OreVeinLocation implements IWaypointAndLocationProvider {
 
@@ -115,8 +116,8 @@ public class OreVeinLocation implements IWaypointAndLocationProvider {
         return oreVeinPosition.veinType.oreMaterialProvider.getColor();
     }
 
-    public IIcon getIconFromPrimaryOre() {
-        return oreVeinPosition.veinType.oreMaterialProvider.getIcon();
+    public IIconContainer getIconsFromPrimaryOre() {
+        return oreVeinPosition.veinType.oreMaterialProvider.getIconContainer();
     }
 
     public short getPrimaryOreMeta() {

--- a/src/main/java/com/sinthoras/visualprospecting/integration/model/render/OreVeinRenderStep.java
+++ b/src/main/java/com/sinthoras/visualprospecting/integration/model/render/OreVeinRenderStep.java
@@ -17,6 +17,7 @@ import com.sinthoras.visualprospecting.integration.model.locations.OreVeinLocati
 
 import codechicken.nei.api.ShortcutInputHandler;
 import gregtech.api.GregTechAPI;
+import gregtech.api.interfaces.IIconContainer;
 
 public class OreVeinRenderStep extends UniversalInteractableStep<OreVeinLocation> {
 
@@ -56,7 +57,11 @@ public class OreVeinRenderStep extends UniversalInteractableStep<OreVeinLocation
         final IIcon blockIcon = Blocks.stone.getIcon(0, 0);
         DrawUtils.drawQuad(blockIcon, topX, topY, width, height, 0xFFFFFF, 255);
 
-        DrawUtils.drawQuad(location.getIconFromPrimaryOre(), topX, topY, width, height, location.getColor(), 255);
+        final IIconContainer oreIconContainer = location.getIconsFromPrimaryOre();
+        final IIcon oreIcon = oreIconContainer.getIcon();
+        DrawUtils.drawQuad(oreIcon, topX, topY, width, height, location.getColor(), 255);
+        final IIcon oreIconOverlay = oreIconContainer.getOverlayIcon();
+        if (oreIconOverlay != null) DrawUtils.drawQuad(oreIconOverlay, topX, topY, width, height, 0xFFFFFF, 255);
 
         if (!location.drawSearchHighlight() || location.isDepleted()) {
             DrawUtils.drawRect(topX, topY, width, height, 0x000000, 150);


### PR DESCRIPTION
fix https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/20744

Before:

<img width="254" height="160" alt="Image" src="https://private-user-images.githubusercontent.com/48237322/474923734-975c0583-4185-4b99-982f-b05cad1d3e31.png?jwt=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJnaXRodWIuY29tIiwiYXVkIjoicmF3LmdpdGh1YnVzZXJjb250ZW50LmNvbSIsImtleSI6ImtleTUiLCJleHAiOjE3NTQ0ODQ0NDEsIm5iZiI6MTc1NDQ4NDE0MSwicGF0aCI6Ii80ODIzNzMyMi80NzQ5MjM3MzQtOTc1YzA1ODMtNDE4NS00Yjk5LTk4MmYtYjA1Y2FkMWQzZTMxLnBuZz9YLUFtei1BbGdvcml0aG09QVdTNC1ITUFDLVNIQTI1NiZYLUFtei1DcmVkZW50aWFsPUFLSUFWQ09EWUxTQTUzUFFLNFpBJTJGMjAyNTA4MDYlMkZ1cy1lYXN0LTElMkZzMyUyRmF3czRfcmVxdWVzdCZYLUFtei1EYXRlPTIwMjUwODA2VDEyNDIyMVomWC1BbXotRXhwaXJlcz0zMDAmWC1BbXotU2lnbmF0dXJlPTVmMzYyZjQ5NjFmODg3OWQwODJiYjU3ZTM5ZjMxMmYwYWExZDcwMDU1MjE3OGRlNzk1OTBlNjkwMTA5YTNkNzMmWC1BbXotU2lnbmVkSGVhZGVycz1ob3N0In0.cRHdRHhwYxnkax9KiB3XUasK865IsBT4ab_q-Cfd-PI" style="max-width: 100%; height: auto; max-height: 160px;">

Now:

<img width="854" height="480" alt="2025-08-06_14 22 37" src="https://github.com/user-attachments/assets/24544e06-aa1e-4d86-ac3c-06c1fd8b63b1" />
