### PR TITLE
optimize save/load methods in DimensionCache for ores and fluids

### DIFF
--- a/src/main/java/com/sinthoras/visualprospecting/database/DimensionCache.java
+++ b/src/main/java/com/sinthoras/visualprospecting/database/DimensionCache.java
@@ -74,15 +74,14 @@ public class DimensionCache {
         byte[] depletedFlags = new byte[size];
         NBTTagList veinTypeNamesList = new NBTTagList();
 
-        // Convert collection to array for optimal indexed access
-        OreVeinPosition[] veinArray = veins.toArray(new OreVeinPosition[size]);
-
-        for (int i = 0; i < veinArray.length; i++) {
-            OreVeinPosition vein = veinArray[i];
+        // Single-pass iteration for optimal access pattern
+        int i = 0;
+        for (OreVeinPosition vein : veins) {
             chunkXArray[i] = vein.chunkX;
             chunkZArray[i] = vein.chunkZ;
             depletedFlags[i] = vein.isDepleted() ? (byte) 1 : (byte) 0;
             veinTypeNamesList.appendTag(new net.minecraft.nbt.NBTTagString(vein.veinType.name));
+            i++;
         }
 
         // Store as contiguous arrays - only 4 string operations vs 400,000+
@@ -112,11 +111,9 @@ public class DimensionCache {
         int[] allChunkData = new int[size * chunkDataSize];
         NBTTagList fluidNamesList = new NBTTagList();
 
-        // Convert collection to array for optimal indexed access
-        UndergroundFluidPosition[] fluidArray = fluids.toArray(new UndergroundFluidPosition[size]);
-
-        for (int fluidIndex = 0; fluidIndex < fluidArray.length; fluidIndex++) {
-            UndergroundFluidPosition fluid = fluidArray[fluidIndex];
+        // Single-pass iteration for optimal access pattern
+        int fluidIndex = 0;
+        for (UndergroundFluidPosition fluid : fluids) {
             chunkXArray[fluidIndex] = fluid.chunkX;
             chunkZArray[fluidIndex] = fluid.chunkZ;
             fluidNamesList.appendTag(new net.minecraft.nbt.NBTTagString(fluid.fluid.getName()));
@@ -131,6 +128,7 @@ public class DimensionCache {
                         baseOffset + x * VP.undergroundFluidSizeChunkZ,
                         VP.undergroundFluidSizeChunkZ);
             }
+            fluidIndex++;
         }
 
         // Store as contiguous arrays - minimal string operations


### PR DESCRIPTION
I had a problem with loading the server, i noticed that my server takes several extra minutes than usually empty map, my map has roughly ~389GB in size. Is just my mistake for not setup a general border. Either way, i used [spark agent](https://spark.lucko.me/docs/Standalone-Agent) to profile starting up. I should mention this appears AFTER mod general initialization, just the map loading time is increased far too much.
This is 1st part, second part will be to trying to optimise other mods.
<img width="1885" height="1714" alt="image" src="https://github.com/user-attachments/assets/07c8c399-c7bc-4860-a1f7-e3080dd43dbe" />
Before :
<img width="1840" height="431" alt="image" src="https://github.com/user-attachments/assets/032bce56-e285-4503-85ca-64f71f6f0eb5" />
After : 
<img width="1220" height="128" alt="image" src="https://github.com/user-attachments/assets/cff16dd9-e6cb-4899-99ee-d691b3f0503a" />
General discussion happen there : https://discord.com/channels/181078474394566657/305737190195986433 

I checked with results with empty cache before jar and after jar to ensure that nothing escaped the testing.

I had theory that is mostly operation of loading the VP cache is plagued with compound tag with million entries (hence making it slower).