### PR TITLE
Fix Prospector's Log packet size overflow

### DIFF
--- a/src/main/java/com/sinthoras/visualprospecting/database/OreVeinPosition.java
+++ b/src/main/java/com/sinthoras/visualprospecting/database/OreVeinPosition.java
@@ -1,11 +1,15 @@
 package com.sinthoras.visualprospecting.database;
 
+import static cpw.mods.fml.common.network.ByteBufUtils.varIntByteCount;
+
+import java.nio.charset.StandardCharsets;
+
 import com.sinthoras.visualprospecting.Utils;
 import com.sinthoras.visualprospecting.database.veintypes.VeinType;
 
 public class OreVeinPosition {
 
-    public static final int MAX_BYTES = 3 * Integer.BYTES + Short.BYTES;
+    public static final int BYTES_WITHOUT_VEIN_NAME = 3 * Integer.BYTES + Byte.BYTES;
     public static final OreVeinPosition EMPTY_VEIN = new OreVeinPosition(0, 0, 0, VeinType.NO_VEIN, true);
 
     public final int dimensionId;
@@ -38,6 +42,18 @@ public class OreVeinPosition {
         return Utils.coordChunkToBlock(chunkZ) + 8;
     }
 
+    public int getBytes() {
+        int veinNameLength = veinType.name.getBytes(StandardCharsets.UTF_8).length;
+
+        return BYTES_WITHOUT_VEIN_NAME + veinNameLength;
+    }
+
+    public int getPacketBytes() {
+        int veinNameLength = veinType.name.getBytes(StandardCharsets.UTF_8).length;
+
+        return BYTES_WITHOUT_VEIN_NAME + varIntByteCount(veinNameLength) + veinNameLength;
+    }
+
     public boolean isDepleted() {
         return depleted;
     }
@@ -51,8 +67,4 @@ public class OreVeinPosition {
         return this;
     }
 
-    // Leaving this here for compatability sake
-    public static int getMaxBytes() {
-        return MAX_BYTES;
-    }
 }

--- a/src/main/java/com/sinthoras/visualprospecting/database/TransferCache.java
+++ b/src/main/java/com/sinthoras/visualprospecting/database/TransferCache.java
@@ -23,7 +23,7 @@ public class TransferCache {
         sharedUndergroundFluids.remove(uuid);
         timestamp.remove(uuid);
 
-        final int newEntryBytes = oreVeins.size() * OreVeinPosition.MAX_BYTES
+        final int newEntryBytes = oreVeins.stream().mapToInt(OreVeinPosition::getBytes).sum()
                 + undergroundFluids.size() * UndergroundFluidPosition.BYTES;
 
         while (getUsedMemory() > (Config.maxTransferCacheSizeMB << 20) - newEntryBytes && !timestamp.isEmpty()) {
@@ -50,7 +50,7 @@ public class TransferCache {
     }
 
     private int getUsedMemory() {
-        return sharedOreVeins.values().stream().mapToInt(oreVeins -> oreVeins.size() * OreVeinPosition.MAX_BYTES).sum()
+        return sharedOreVeins.values().stream().flatMap(List::stream).mapToInt(OreVeinPosition::getBytes).sum()
                 + sharedUndergroundFluids.values().stream()
                         .mapToInt(undergroundFluids -> undergroundFluids.size() * UndergroundFluidPosition.BYTES).sum();
     }


### PR DESCRIPTION
The logic for splitting prospecting data across multiple packets failed to account for the variable length orevein string.

fallout from #57

fixes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/18377