### PR TITLE
Prevent crash when search input is an invalid regex pattern

### DIFF
--- a/src/main/java/com/sinthoras/visualprospecting/Utils.java
+++ b/src/main/java/com/sinthoras/visualprospecting/Utils.java
@@ -17,6 +17,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.regex.Pattern;
+import java.util.regex.PatternSyntaxException;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -243,7 +244,11 @@ public class Utils {
     public static @Nullable Pattern getSearchPattern(@NotNull String searchString) {
         if (searchString.isEmpty()) return null;
         final String unquotedRegex = SearchField.getPattern(searchString).pattern().replace("\\Q", "")
-                .replace("\\E", "").replaceAll("[-.+*?\\[^\\]$(){}=!<>|:\\\\]", "\\\\$0");
-        return Pattern.compile(unquotedRegex, Pattern.MULTILINE | Pattern.CASE_INSENSITIVE | Pattern.UNICODE_CASE);
+                .replace("\\E", "");
+        try {
+            return Pattern.compile(unquotedRegex, Pattern.MULTILINE | Pattern.CASE_INSENSITIVE | Pattern.UNICODE_CASE);
+        } catch (PatternSyntaxException e) {
+            return null;
+        }
     }
 }

--- a/src/main/java/com/sinthoras/visualprospecting/Utils.java
+++ b/src/main/java/com/sinthoras/visualprospecting/Utils.java
@@ -243,7 +243,7 @@ public class Utils {
     public static @Nullable Pattern getSearchPattern(@NotNull String searchString) {
         if (searchString.isEmpty()) return null;
         final String unquotedRegex = SearchField.getPattern(searchString).pattern().replace("\\Q", "")
-                .replace("\\E", "");
+                .replace("\\E", "").replaceAll("[-.+*?\\[^\\]$(){}=!<>|:\\\\]", "\\\\$0");
         return Pattern.compile(unquotedRegex, Pattern.MULTILINE | Pattern.CASE_INSENSITIVE | Pattern.UNICODE_CASE);
     }
 }


### PR DESCRIPTION
Fixes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/24280
Fixes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/21193

<img width="669" height="97" alt="image" src="https://github.com/user-attachments/assets/c3e0bb9f-fcb2-4390-ad33-95ecfa1e1f80" />

Tested with `.+*?[^]$(){}=!<>|:-\`