### PR TITLE
Add cleanup of VP files on WorldDeletionEvent

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -1,6 +1,6 @@
 dependencies {
     api('com.github.GTNewHorizons:Navigator:1.0.17:dev')
-    api('com.github.GTNewHorizons:GTNHLib:0.9.47:dev')
+    api('com.github.GTNewHorizons:GTNHLib:0.9.57:dev')
     api('com.github.GTNewHorizons:GT5-Unofficial:5.09.52.399:dev')
 
     runtimeOnlyNonPublishable(rfg.deobf('maven.modrinth:journeymap:5.2.6'))

--- a/src/main/java/com/sinthoras/visualprospecting/VPMod.java
+++ b/src/main/java/com/sinthoras/visualprospecting/VPMod.java
@@ -22,7 +22,9 @@ import gregtech.crossmod.visualprospecting.VisualProspectingDatabase;
         version = Tags.VERSION,
         name = Tags.MODNAME,
         acceptedMinecraftVersions = "[1.7.10]",
-        dependencies = "required-after:gregtech;" + "required-after:NotEnoughItems;" + "after:navigator;")
+        dependencies = "required-after:gregtech;" + "required-after:NotEnoughItems;"
+                + "required-after:gtnhlib;"
+                + "after:navigator;")
 public class VPMod {
 
     @SidedProxy(clientSide = Tags.GROUPNAME + ".hooks.HooksClient", serverSide = Tags.GROUPNAME + ".hooks.HooksShared")

--- a/src/main/java/com/sinthoras/visualprospecting/hooks/HooksEventBus.java
+++ b/src/main/java/com/sinthoras/visualprospecting/hooks/HooksEventBus.java
@@ -1,5 +1,7 @@
 package com.sinthoras.visualprospecting.hooks;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
+
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
@@ -58,10 +60,10 @@ public class HooksEventBus {
             }
         }
 
-        UUID userUUID = VPSaveCleanupUtils.getUUIDForCurrentUser(mcDataDir, currentUsername);
+        UUID userUUID = Minecraft.getMinecraft().getSession().func_148256_e().getId();
         if (userUUID == null) {
             VP.LOG.debug("Unable to read userUUID for current user. Attempting to use fallback instead");
-            userUUID = VPSaveCleanupUtils.getUUIDFromBytesForCurrentUser(currentUsername);
+            userUUID = UUID.nameUUIDFromBytes(("OfflinePlayer:" + currentUsername).getBytes(UTF_8));
         }
         Path vpClientPathFull = vpBasePath.resolve("client").resolve(userUUID.toString()).resolve(worldId);
         if (Files.isDirectory(vpClientPathFull)) {

--- a/src/main/java/com/sinthoras/visualprospecting/hooks/HooksEventBus.java
+++ b/src/main/java/com/sinthoras/visualprospecting/hooks/HooksEventBus.java
@@ -1,12 +1,27 @@
 package com.sinthoras.visualprospecting.hooks;
 
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.UUID;
+
+import net.minecraft.client.Minecraft;
 import net.minecraftforge.event.world.WorldEvent;
 
+import org.apache.commons.io.FileUtils;
+
+import com.gtnewhorizon.gtnhlib.client.event.WorldDeletionEvent;
+import com.sinthoras.visualprospecting.Tags;
 import com.sinthoras.visualprospecting.Utils;
+import com.sinthoras.visualprospecting.VP;
 import com.sinthoras.visualprospecting.database.ClientCache;
 import com.sinthoras.visualprospecting.database.ServerCache;
+import com.sinthoras.visualprospecting.utils.VPSaveCleanupUtils;
 
 import cpw.mods.fml.common.eventhandler.SubscribeEvent;
+import cpw.mods.fml.relauncher.Side;
+import cpw.mods.fml.relauncher.SideOnly;
 
 public class HooksEventBus {
 
@@ -20,5 +35,42 @@ public class HooksEventBus {
     @SubscribeEvent
     public void onEvent(WorldEvent.Save event) {
         ServerCache.instance.saveVeinCache();
+    }
+
+    @SideOnly(Side.CLIENT)
+    @SubscribeEvent
+    public void onWorldDeletionEvent(WorldDeletionEvent event) {
+        File mcDataDir = Minecraft.getMinecraft().mcDataDir;
+        Path vpBasePath = mcDataDir.toPath().resolve(Tags.MODID);
+        String currentUsername = Minecraft.getMinecraft().getSession().getUsername();
+
+        String worldId = VPSaveCleanupUtils.getVisualProspectingWorldId(mcDataDir, event.worldName);
+        if (worldId == null) {
+            VP.LOG.warn("Unable to read VP worldID for world \"{}\", can't cleanup any VP data", event.worldName);
+            return;
+        }
+        Path vpServerPathFull = vpBasePath.resolve("server").resolve(worldId);
+        if (Files.isDirectory(vpServerPathFull)) {
+            try {
+                FileUtils.deleteDirectory(vpServerPathFull.toFile());
+            } catch (IOException e) {
+                VP.LOG.warn("Failed to delete Visual Prospecting server data found at {}", vpServerPathFull);
+            }
+        }
+
+        UUID userUUID = VPSaveCleanupUtils.getUUIDForCurrentUser(mcDataDir, currentUsername);
+        if (userUUID == null) {
+            VP.LOG.debug("Unable to read userUUID for current user. Attempting to use fallback instead");
+            userUUID = VPSaveCleanupUtils.getUUIDFromBytesForCurrentUser(currentUsername);
+        }
+        Path vpClientPathFull = vpBasePath.resolve("client").resolve(userUUID.toString()).resolve(worldId);
+        if (Files.isDirectory(vpClientPathFull)) {
+            try {
+                FileUtils.deleteDirectory(vpClientPathFull.toFile());
+            } catch (IOException e) {
+                VP.LOG.warn("Failed to delete Visual Prospecting client data found at {}", vpClientPathFull);
+            }
+        }
+
     }
 }

--- a/src/main/java/com/sinthoras/visualprospecting/utils/VPSaveCleanupUtils.java
+++ b/src/main/java/com/sinthoras/visualprospecting/utils/VPSaveCleanupUtils.java
@@ -1,0 +1,94 @@
+package com.sinthoras.visualprospecting.utils;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileReader;
+import java.io.IOException;
+import java.util.Map;
+import java.util.UUID;
+
+import net.minecraft.nbt.CompressedStreamTools;
+import net.minecraft.nbt.NBTTagCompound;
+
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+import com.sinthoras.visualprospecting.database.WorldIdHandler;
+
+public final class VPSaveCleanupUtils {
+
+    /**
+     * Normally you obtain the player UUID by doing {@code Minecraft.getMinecraft().thePlayer.getPersistentID()}
+     * <p>
+     * This is not possible in the game state where a save deletion occurs because it's not loaded yet. Therefore, the
+     * only option to find the player UUID is to attempt to read it from cache in usernamecache.json.
+     * </p>
+     * 
+     * @param mcDataDir       Full path to Minecraft instance
+     * @param currentUsername Name of current user
+     * @return The UUID matching the current user logged in the client or null if not found
+     */
+    public static UUID getUUIDForCurrentUser(File mcDataDir, String currentUsername) {
+
+        File usernameFile = new File(mcDataDir, "usernamecache.json");
+        if (!usernameFile.exists()) {
+            return null;
+        }
+
+        try (FileReader reader = new FileReader(usernameFile)) {
+            JsonObject usernameObj = new JsonParser().parse(reader).getAsJsonObject();
+            for (Map.Entry<String, JsonElement> entry : usernameObj.entrySet()) {
+                JsonElement value = entry.getValue();
+                if (value != null && currentUsername.equalsIgnoreCase(value.getAsString())) {
+                    try {
+                        return UUID.fromString(entry.getKey());
+                    } catch (IllegalArgumentException ignored) {}
+                }
+            }
+        } catch (IOException e) {
+            return null;
+        }
+        return null;
+    }
+
+    /**
+     * In case {@link #getUUIDForCurrentUser(File, String)} fail at helping us locate the data this allows us to attempt
+     * an alternative approach.
+     * 
+     * @return UUID for an offline player
+     */
+    public static UUID getUUIDFromBytesForCurrentUser(String username) {
+        return UUID.nameUUIDFromBytes(("OfflinePlayer:" + username).getBytes(UTF_8));
+    }
+
+    /**
+     * The name of save folder is created in {@link WorldIdHandler} by combining world name and a randomly generated
+     * UUID. The value is then saved into visualprospecting.dat file so we have to go read it there.
+     * 
+     * @param mcDataDir   Full path to Minecraft instance
+     * @param worldFolder Directory name for world we want the VP worldId of
+     * @return worldId VP value for this world
+     */
+    public static String getVisualProspectingWorldId(File mcDataDir, String worldFolder) {
+        File vpDat = mcDataDir.toPath().resolve("saves").resolve(worldFolder).resolve("data")
+                .resolve("visualprospecting.dat").toFile();
+        if (!vpDat.exists()) {
+            return null;
+        }
+
+        try (FileInputStream vpFIS = new FileInputStream(vpDat)) {
+            NBTTagCompound vpNBT = CompressedStreamTools.readCompressed(vpFIS);
+            if (vpNBT.hasKey("data")) {
+                NBTTagCompound data = vpNBT.getCompoundTag("data");
+                if (data.hasKey("wId")) {
+                    return data.getString("wId");
+                }
+            }
+            return null;
+        } catch (Exception e) {
+            return null;
+        }
+    }
+}

--- a/src/main/java/com/sinthoras/visualprospecting/utils/VPSaveCleanupUtils.java
+++ b/src/main/java/com/sinthoras/visualprospecting/utils/VPSaveCleanupUtils.java
@@ -1,67 +1,14 @@
 package com.sinthoras.visualprospecting.utils;
 
-import static java.nio.charset.StandardCharsets.UTF_8;
-
 import java.io.File;
 import java.io.FileInputStream;
-import java.io.FileReader;
-import java.io.IOException;
-import java.util.Map;
-import java.util.UUID;
 
 import net.minecraft.nbt.CompressedStreamTools;
 import net.minecraft.nbt.NBTTagCompound;
 
-import com.google.gson.JsonElement;
-import com.google.gson.JsonObject;
-import com.google.gson.JsonParser;
 import com.sinthoras.visualprospecting.database.WorldIdHandler;
 
 public final class VPSaveCleanupUtils {
-
-    /**
-     * Normally you obtain the player UUID by doing {@code Minecraft.getMinecraft().thePlayer.getPersistentID()}
-     * <p>
-     * This is not possible in the game state where a save deletion occurs because it's not loaded yet. Therefore, the
-     * only option to find the player UUID is to attempt to read it from cache in usernamecache.json.
-     * </p>
-     * 
-     * @param mcDataDir       Full path to Minecraft instance
-     * @param currentUsername Name of current user
-     * @return The UUID matching the current user logged in the client or null if not found
-     */
-    public static UUID getUUIDForCurrentUser(File mcDataDir, String currentUsername) {
-
-        File usernameFile = new File(mcDataDir, "usernamecache.json");
-        if (!usernameFile.exists()) {
-            return null;
-        }
-
-        try (FileReader reader = new FileReader(usernameFile)) {
-            JsonObject usernameObj = new JsonParser().parse(reader).getAsJsonObject();
-            for (Map.Entry<String, JsonElement> entry : usernameObj.entrySet()) {
-                JsonElement value = entry.getValue();
-                if (value != null && currentUsername.equalsIgnoreCase(value.getAsString())) {
-                    try {
-                        return UUID.fromString(entry.getKey());
-                    } catch (IllegalArgumentException ignored) {}
-                }
-            }
-        } catch (IOException e) {
-            return null;
-        }
-        return null;
-    }
-
-    /**
-     * In case {@link #getUUIDForCurrentUser(File, String)} fail at helping us locate the data this allows us to attempt
-     * an alternative approach.
-     * 
-     * @return UUID for an offline player
-     */
-    public static UUID getUUIDFromBytesForCurrentUser(String username) {
-        return UUID.nameUUIDFromBytes(("OfflinePlayer:" + username).getBytes(UTF_8));
-    }
 
     /**
      * The name of save folder is created in {@link WorldIdHandler} by combining world name and a randomly generated


### PR DESCRIPTION
Following PR https://github.com/GTNewHorizons/GTNHLib/pull/338

Use introduced `WorldDeletionEvent` to delete VP data for that save.

VP have a bit of a complicated directories structure for each world:
- .minecraft/`visualprospecting/<playerID>/<worldId>`
- .minecraft/`visualprospecting/server/<worldId>`

`worldId` is uniquely made from world name + randomUUID then stored into the visualprospecting.dat file in the world save folder.
`playerID` is based on the player persistent ID.

Since both those values are not readily available from the world selection we end up needing to go get them manually where they are stored.
It should be reliable for worldId, a bit less for playerID but with the included fallback it is as far as we can automate it.