### PR TITLE
Fix registering vein on VeinGenerateEvent

### DIFF
--- a/src/main/java/com/sinthoras/visualprospecting/database/ServerCache.java
+++ b/src/main/java/com/sinthoras/visualprospecting/database/ServerCache.java
@@ -47,13 +47,11 @@ public class ServerCache extends WorldCache {
     @SubscribeEvent
     public void onVeinGenerated(VeinGenerateEvent event) {
         if (event.result == WorldgenGTOreLayer.ORE_PLACED && !event.layer.mWorldGenName.equals("NoOresInVein")) {
-            if (event.chunkX == event.oreSeedX && event.chunkZ == event.oreSeedZ) {
-                notifyOreVeinGeneration(
-                        event.world.provider.dimensionId,
-                        event.oreSeedX,
-                        event.oreSeedZ,
-                        event.layer.mWorldGenName);
-            }
+            notifyOreVeinGeneration(
+                    event.world.provider.dimensionId,
+                    event.oreSeedX,
+                    event.oreSeedZ,
+                    event.layer.mWorldGenName);
         }
     }
 


### PR DESCRIPTION
Fix https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/24692
But only for newly generated chunks since it rely on the VeinGenerateEvent from GTWorldgen.

Upside is should be fairly clean because if this event is posted it's that a vein was generated even if it fire on a non central ore chunk.

It doesn't seem to have adverse effects from testing on a few worlds in row (can see a comparison on a small sample in the comments of the issue).


For all existing map area this won't change anything. /vp_recache doesn't have the ability to rely on the event so it's doing guess work instead and that's a much more complicated thing to touch.