### PR TITLE
Add admin command to upload client cache into your team

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ Disable via `B:enableTeamSharing=false` in `config/visualprospecting.cfg`.
 Admin commands:
  - `/vp_team_info [player] [detailed]`: inspect a team's prospection record.
  - `/vp_team_clear <player>`: wipe a team's server-side prospection record (op/console).
+ - `/vp_team_upload <player>`: Push a player's local cache into their team's record (op/console).
 
 ### Reset Progress
 

--- a/src/main/java/com/sinthoras/visualprospecting/hooks/HooksShared.java
+++ b/src/main/java/com/sinthoras/visualprospecting/hooks/HooksShared.java
@@ -22,6 +22,7 @@ import com.sinthoras.visualprospecting.item.ProspectorsLog;
 import com.sinthoras.visualprospecting.network.ProspectingNotification;
 import com.sinthoras.visualprospecting.network.ProspectingRequest;
 import com.sinthoras.visualprospecting.network.ProspectionSharing;
+import com.sinthoras.visualprospecting.network.RequestTeamUploadMessage;
 import com.sinthoras.visualprospecting.network.TeamCatchupNotification;
 import com.sinthoras.visualprospecting.network.VeinDepletionMessage;
 import com.sinthoras.visualprospecting.network.WorldIdNotification;
@@ -29,6 +30,7 @@ import com.sinthoras.visualprospecting.task.TaskManager;
 import com.sinthoras.visualprospecting.teams.TeamClearCommand;
 import com.sinthoras.visualprospecting.teams.TeamInfoCommand;
 import com.sinthoras.visualprospecting.teams.TeamProspectionData;
+import com.sinthoras.visualprospecting.teams.TeamUploadCommand;
 
 import cpw.mods.fml.common.FMLCommonHandler;
 import cpw.mods.fml.common.event.FMLInitializationEvent;
@@ -92,6 +94,11 @@ public class HooksShared {
                 TeamCatchupNotification.class,
                 networkId++,
                 Side.CLIENT);
+        VP.network.registerMessage(
+                RequestTeamUploadMessage.ClientHandler.class,
+                RequestTeamUploadMessage.class,
+                networkId++,
+                Side.CLIENT);
 
         ProspectorsLog.instance = new ProspectorsLog();
         GameRegistry.registerItem(ProspectorsLog.instance, ProspectorsLog.instance.getUnlocalizedName());
@@ -151,6 +158,7 @@ public class HooksShared {
         // Team-sharing debug commands
         event.registerServerCommand(new TeamInfoCommand());
         event.registerServerCommand(new TeamClearCommand());
+        event.registerServerCommand(new TeamUploadCommand());
     }
 
     public void fmlLifeCycleEvent(FMLServerStartedEvent event) {}

--- a/src/main/java/com/sinthoras/visualprospecting/network/ProspectionSharing.java
+++ b/src/main/java/com/sinthoras/visualprospecting/network/ProspectionSharing.java
@@ -19,6 +19,7 @@ import cpw.mods.fml.common.network.simpleimpl.IMessage;
 import cpw.mods.fml.common.network.simpleimpl.IMessageHandler;
 import cpw.mods.fml.common.network.simpleimpl.MessageContext;
 import io.netty.buffer.ByteBuf;
+import it.unimi.dsi.fastutil.objects.Object2BooleanOpenHashMap;
 
 public class ProspectionSharing implements IMessage {
 
@@ -97,7 +98,7 @@ public class ProspectionSharing implements IMessage {
 
         private static final Map<EntityPlayerMP, List<OreVeinPosition>> oreVeins = new HashMap<>();
         private static final Map<EntityPlayerMP, List<UndergroundFluidPosition>> undergroundFluids = new HashMap<>();
-        private static final Map<EntityPlayerMP, Boolean> routeToTeam = new HashMap<>();
+        private static final Object2BooleanOpenHashMap<EntityPlayerMP> routeToTeam = new Object2BooleanOpenHashMap<>();
 
         @Override
         public IMessage onMessage(ProspectionSharing message, MessageContext ctx) {
@@ -121,7 +122,7 @@ public class ProspectionSharing implements IMessage {
             if (message.isLastMessage) {
                 List<OreVeinPosition> veins = oreVeins.remove(player);
                 List<UndergroundFluidPosition> fluids = undergroundFluids.remove(player);
-                boolean toTeam = routeToTeam.remove(player) == Boolean.TRUE;
+                boolean toTeam = routeToTeam.removeBoolean(player);
                 if (toTeam) {
                     TeamProspectionDispatcher
                             .deliverProspectingResults(player, new ProspectingNotification(veins, fluids), false);

--- a/src/main/java/com/sinthoras/visualprospecting/network/ProspectionSharing.java
+++ b/src/main/java/com/sinthoras/visualprospecting/network/ProspectionSharing.java
@@ -12,6 +12,7 @@ import com.sinthoras.visualprospecting.database.ClientCache;
 import com.sinthoras.visualprospecting.database.OreVeinPosition;
 import com.sinthoras.visualprospecting.database.TransferCache;
 import com.sinthoras.visualprospecting.database.UndergroundFluidPosition;
+import com.sinthoras.visualprospecting.teams.TeamProspectionDispatcher;
 import com.sinthoras.visualprospecting.utils.VPByteBufUtils;
 
 import cpw.mods.fml.common.network.simpleimpl.IMessage;
@@ -21,13 +22,14 @@ import io.netty.buffer.ByteBuf;
 
 public class ProspectionSharing implements IMessage {
 
-    private static final int BYTES_OVERHEAD = Byte.BYTES + 2 * Byte.BYTES + 2 * Integer.BYTES;
+    private static final int BYTES_OVERHEAD = Byte.BYTES + 3 * Byte.BYTES + 2 * Integer.BYTES;
 
     final List<OreVeinPosition> oreVeins = new ArrayList<>();
     final List<UndergroundFluidPosition> undergroundFluids = new ArrayList<>();
     private int bytesUsed = BYTES_OVERHEAD;
     boolean isFirstMessage = false;
     boolean isLastMessage = false;
+    boolean routeToTeam = false;
 
     public ProspectionSharing() {}
 
@@ -62,6 +64,10 @@ public class ProspectionSharing implements IMessage {
         this.isLastMessage = isLastMessage;
     }
 
+    public void setRouteToTeam(boolean routeToTeam) {
+        this.routeToTeam = routeToTeam;
+    }
+
     public int getPacketBytes() {
         return BYTES_OVERHEAD + oreVeins.stream().mapToInt(OreVeinPosition::getPacketBytes).sum()
                 + UndergroundFluidPosition.BYTES * undergroundFluids.size();
@@ -71,6 +77,7 @@ public class ProspectionSharing implements IMessage {
     public void fromBytes(ByteBuf buf) {
         isFirstMessage = buf.readByte() > 0;
         isLastMessage = buf.readByte() > 0;
+        routeToTeam = buf.readByte() > 0;
 
         oreVeins.addAll(VPByteBufUtils.ReadOreVeinPositions(buf));
         undergroundFluids.addAll(VPByteBufUtils.ReadUndergroundFluidPositions(buf));
@@ -80,6 +87,7 @@ public class ProspectionSharing implements IMessage {
     public void toBytes(ByteBuf buf) {
         buf.writeByte(isFirstMessage ? 1 : 0);
         buf.writeByte(isLastMessage ? 1 : 0);
+        buf.writeByte(routeToTeam ? 1 : 0);
 
         VPByteBufUtils.WriteOreVeinPositions(buf, oreVeins);
         VPByteBufUtils.WriteUndergroundFluidPositions(buf, undergroundFluids);
@@ -89,6 +97,7 @@ public class ProspectionSharing implements IMessage {
 
         private static final Map<EntityPlayerMP, List<OreVeinPosition>> oreVeins = new HashMap<>();
         private static final Map<EntityPlayerMP, List<UndergroundFluidPosition>> undergroundFluids = new HashMap<>();
+        private static final Map<EntityPlayerMP, Boolean> routeToTeam = new HashMap<>();
 
         @Override
         public IMessage onMessage(ProspectionSharing message, MessageContext ctx) {
@@ -102,6 +111,7 @@ public class ProspectionSharing implements IMessage {
             if (message.isFirstMessage) {
                 oreVeins.put(player, new ArrayList<>());
                 undergroundFluids.put(player, new ArrayList<>());
+                routeToTeam.put(player, message.routeToTeam);
             }
             if (!oreVeins.containsKey(player) || !undergroundFluids.containsKey(player)) {
                 return null;
@@ -109,12 +119,15 @@ public class ProspectionSharing implements IMessage {
             oreVeins.get(player).addAll(message.oreVeins);
             undergroundFluids.get(player).addAll(message.undergroundFluids);
             if (message.isLastMessage) {
-                TransferCache.instance.addClientProspectionData(
-                        player.getPersistentID().toString(),
-                        oreVeins.get(player),
-                        undergroundFluids.get(player));
-                oreVeins.remove(player);
-                undergroundFluids.remove(player);
+                List<OreVeinPosition> veins = oreVeins.remove(player);
+                List<UndergroundFluidPosition> fluids = undergroundFluids.remove(player);
+                boolean toTeam = routeToTeam.remove(player) == Boolean.TRUE;
+                if (toTeam) {
+                    TeamProspectionDispatcher
+                            .deliverProspectingResults(player, new ProspectingNotification(veins, fluids), false);
+                } else {
+                    TransferCache.instance.addClientProspectionData(player.getPersistentID().toString(), veins, fluids);
+                }
             }
             return null;
         }

--- a/src/main/java/com/sinthoras/visualprospecting/network/RequestTeamUploadMessage.java
+++ b/src/main/java/com/sinthoras/visualprospecting/network/RequestTeamUploadMessage.java
@@ -1,0 +1,35 @@
+package com.sinthoras.visualprospecting.network;
+
+import com.sinthoras.visualprospecting.database.ClientCache;
+import com.sinthoras.visualprospecting.task.SnapshotUploadTask;
+import com.sinthoras.visualprospecting.task.TaskManager;
+import com.sinthoras.visualprospecting.teams.TeamProspectionData;
+
+import cpw.mods.fml.common.network.simpleimpl.IMessage;
+import cpw.mods.fml.common.network.simpleimpl.IMessageHandler;
+import cpw.mods.fml.common.network.simpleimpl.MessageContext;
+import io.netty.buffer.ByteBuf;
+
+/**
+ * Server → client trigger: ask the recipient to push their {@link ClientCache} to the server, routed into their team's
+ * {@link TeamProspectionData}.
+ */
+public class RequestTeamUploadMessage implements IMessage {
+
+    public RequestTeamUploadMessage() {}
+
+    @Override
+    public void fromBytes(ByteBuf buf) {}
+
+    @Override
+    public void toBytes(ByteBuf buf) {}
+
+    public static class ClientHandler implements IMessageHandler<RequestTeamUploadMessage, IMessage> {
+
+        @Override
+        public IMessage onMessage(RequestTeamUploadMessage message, MessageContext ctx) {
+            TaskManager.CLIENT_INSTANCE.addTask(new SnapshotUploadTask(true));
+            return null;
+        }
+    }
+}

--- a/src/main/java/com/sinthoras/visualprospecting/task/SnapshotUploadTask.java
+++ b/src/main/java/com/sinthoras/visualprospecting/task/SnapshotUploadTask.java
@@ -15,12 +15,18 @@ public class SnapshotUploadTask implements ITask {
 
     private final List<OreVeinPosition> oreVeins;
     private final List<UndergroundFluidPosition> undergroundFluids;
+    private final boolean routeToTeam;
     private long lastUpload = 0;
     private boolean firstMessage = true;
 
     public SnapshotUploadTask() {
+        this(false);
+    }
+
+    public SnapshotUploadTask(boolean routeToTeam) {
         oreVeins = ClientCache.instance.getAllOreVeins();
         undergroundFluids = ClientCache.instance.getAllUndergroundFluids();
+        this.routeToTeam = routeToTeam;
     }
 
     @Override
@@ -42,6 +48,7 @@ public class SnapshotUploadTask implements ITask {
             firstMessage = false;
 
             packet.setLastMessage(listsEmpty());
+            packet.setRouteToTeam(routeToTeam);
 
             VP.network.sendToServer(packet);
         }

--- a/src/main/java/com/sinthoras/visualprospecting/teams/TeamProspectionDispatcher.java
+++ b/src/main/java/com/sinthoras/visualprospecting/teams/TeamProspectionDispatcher.java
@@ -35,12 +35,18 @@ public final class TeamProspectionDispatcher {
      */
     public static void deliverProspectingResults(EntityPlayerMP player, List<OreVeinPosition> oreVeins,
             List<UndergroundFluidPosition> fluids) {
-        deliverProspectingResults(player, new ProspectingNotification(oreVeins, fluids));
+        deliverProspectingResults(player, new ProspectingNotification(oreVeins, fluids), true);
     }
 
     public static void deliverProspectingResults(EntityPlayerMP player, ProspectingNotification notification) {
-        // Notify the originating player with the pre-built notification.
-        VP.network.sendTo(notification, player);
+        deliverProspectingResults(player, notification, true);
+    }
+
+    public static void deliverProspectingResults(EntityPlayerMP player, ProspectingNotification notification,
+            boolean notifySelf) {
+        if (notifySelf) {
+            VP.network.sendTo(notification, player);
+        }
 
         if (!Config.enableTeamSharing) return;
 

--- a/src/main/java/com/sinthoras/visualprospecting/teams/TeamUploadCommand.java
+++ b/src/main/java/com/sinthoras/visualprospecting/teams/TeamUploadCommand.java
@@ -1,0 +1,100 @@
+package com.sinthoras.visualprospecting.teams;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+
+import net.minecraft.command.CommandBase;
+import net.minecraft.command.ICommandSender;
+import net.minecraft.entity.player.EntityPlayerMP;
+import net.minecraft.server.MinecraftServer;
+import net.minecraft.util.ChatComponentTranslation;
+import net.minecraft.util.EnumChatFormatting;
+import net.minecraft.util.IChatComponent;
+import net.minecraft.util.StatCollector;
+
+import com.gtnewhorizon.gtnhlib.teams.Team;
+import com.gtnewhorizon.gtnhlib.teams.TeamManager;
+import com.sinthoras.visualprospecting.Config;
+import com.sinthoras.visualprospecting.VP;
+import com.sinthoras.visualprospecting.network.RequestTeamUploadMessage;
+
+/**
+ * {@code /vp_team_upload <player>}: ask {@code <player>}'s client to push its {@code ClientCache} into the team's
+ * {@link TeamProspectionData}.
+ */
+public class TeamUploadCommand extends CommandBase {
+
+    @Override
+    public String getCommandName() {
+        return "vp_team_upload";
+    }
+
+    @Override
+    public String getCommandUsage(ICommandSender sender) {
+        return StatCollector.translateToLocal("visualprospecting.teamupload.command");
+    }
+
+    @Override
+    public int getRequiredPermissionLevel() {
+        return 2;
+    }
+
+    @Override
+    public boolean canCommandSenderUseCommand(ICommandSender sender) {
+        if (sender instanceof EntityPlayerMP player) {
+            if (Objects.equals(player.mcServer.getServerOwner(), sender.getCommandSenderName())) {
+                return true;
+            }
+        }
+        return super.canCommandSenderUseCommand(sender);
+    }
+
+    @Override
+    public List<String> addTabCompletionOptions(ICommandSender sender, String[] args) {
+        if (args.length == 1) {
+            return getListOfStringsMatchingLastWord(args, MinecraftServer.getServer().getAllUsernames());
+        }
+        return Collections.emptyList();
+    }
+
+    @Override
+    public void processCommand(ICommandSender sender, String[] args) {
+        if (args.length != 1) {
+            sendError(sender, "visualprospecting.command.usage_error", getCommandName());
+            return;
+        }
+
+        if (!Config.enableTeamSharing) {
+            sendError(sender, "visualprospecting.teamcommand.sharing_disabled");
+            return;
+        }
+
+        EntityPlayerMP target = MinecraftServer.getServer().getConfigurationManager().func_152612_a(args[0]);
+        if (target == null) {
+            sendError(sender, "visualprospecting.teamcommand.player_offline", args[0]);
+            return;
+        }
+
+        Team team = TeamManager.getTeamByPlayer(target.getUniqueID());
+        if (team == null) {
+            sendError(sender, "visualprospecting.teamcommand.no_team", target.getCommandSenderName());
+            return;
+        }
+
+        VP.network.sendTo(new RequestTeamUploadMessage(), target);
+
+        IChatComponent msg = new ChatComponentTranslation(
+                "visualprospecting.teamupload.requested",
+                target.getCommandSenderName(),
+                team.getTeamName());
+        msg.getChatStyle().setColor(EnumChatFormatting.GREEN);
+        sender.addChatMessage(msg);
+    }
+
+    private static void sendError(ICommandSender sender, String translationKey, Object... args) {
+        IChatComponent msg = new ChatComponentTranslation(translationKey, args);
+        msg.getChatStyle().setColor(EnumChatFormatting.RED);
+        sender.addChatMessage(msg);
+    }
+}

--- a/src/main/resources/assets/visualprospecting/lang/en_US.lang
+++ b/src/main/resources/assets/visualprospecting/lang/en_US.lang
@@ -62,3 +62,6 @@ visualprospecting.teaminfo.summary=  Across %s dim(s): %s veins (%s depleted), %
 visualprospecting.teaminfo.dim_line=    Dim %s: %s veins (%s depleted), %s fluids
 visualprospecting.teamclear.command=/vp_team_clear <player>: Delete that player team prospection record.
 visualprospecting.teamclear.success=Cleared team "%s": Removed %s veins and %s fluids.
+visualprospecting.teamcommand.sharing_disabled=Team sharing is disabled in the server config.
+visualprospecting.teamupload.command=/vp_team_upload <player>: Push that player's local cache into their team's record.
+visualprospecting.teamupload.requested=Requested upload of %s's local cache into team "%s".


### PR DESCRIPTION
Follow up on https://github.com/GTNewHorizons/VisualProspecting/pull/85

New command: `/vp_team_upload <player>`
OP/Console only command to trigger a client upload of a player local cache into their team (broadcasted as any other discovery to the rest of the team)