### PR TITLE
Attempt at improving performance of vein/fluid layer in map

### DIFF
--- a/src/main/java/com/sinthoras/visualprospecting/Config.java
+++ b/src/main/java/com/sinthoras/visualprospecting/Config.java
@@ -15,8 +15,8 @@ public class Config {
         public static final int cacheGenerationLogUpdateMinTime = 5;
         public static final boolean recacheVeins = false;
         public static final int minDelayBetweenVeinRequests = 2000;
-        public static final int minZoomLevelForOreLabel = 1;
-        public static final int minZoomLevelForUndergroundFluidDetails = 2;
+        public static final int minZoomLevelForOreLabel = 2;
+        public static final int minZoomLevelForUndergroundFluidDetails = 3;
         public static final int uploadBandwidthBytes = 2000000;
         public static final int maxTransferCacheSizeMB = 50;
         public static final boolean enableVoxelMapWaypointsByDefault = false;

--- a/src/main/java/com/sinthoras/visualprospecting/integration/model/locations/OreVeinLocation.java
+++ b/src/main/java/com/sinthoras/visualprospecting/integration/model/locations/OreVeinLocation.java
@@ -31,6 +31,8 @@ public class OreVeinLocation implements IWaypointAndLocationProvider {
     private final OreVeinPosition oreVeinPosition;
     private final String name;
     private final List<String> materialNames;
+    private final IIconContainer iconContainer;
+    private final int color;
 
     private boolean isActiveAsWaypoint;
 
@@ -39,6 +41,10 @@ public class OreVeinLocation implements IWaypointAndLocationProvider {
         name = EnumChatFormatting.WHITE + oreVeinPosition.veinType.getVeinName();
         materialNames = oreVeinPosition.veinType.getOreMaterialNames().stream()
                 .map(materialName -> EnumChatFormatting.GRAY + materialName).collect(Collectors.toList());
+        final IOreMaterial representativeOre = oreVeinPosition.veinType.representativeOre;
+        final TextureSet textureSet = representativeOre.getTextureSet();
+        iconContainer = textureSet.mTextures[OrePrefixes.ore.getTextureIndex()];
+        color = LightingHelper.getColor(representativeOre.getRGBA());
     }
 
     @Override
@@ -117,13 +123,11 @@ public class OreVeinLocation implements IWaypointAndLocationProvider {
     }
 
     public int getColor() {
-        return LightingHelper.getColor(getRepresentativeOre().getRGBA());
+        return color;
     }
 
     public IIconContainer getIconFromRepresentativeOre() {
-        TextureSet textureSet = getRepresentativeOre().getTextureSet();
-
-        return textureSet.mTextures[OrePrefixes.ore.getTextureIndex()];
+        return iconContainer;
     }
 
     public IOreMaterial getRepresentativeOre() {

--- a/src/main/java/com/sinthoras/visualprospecting/integration/model/render/OreVeinRenderStep.java
+++ b/src/main/java/com/sinthoras/visualprospecting/integration/model/render/OreVeinRenderStep.java
@@ -44,6 +44,15 @@ public class OreVeinRenderStep extends UniversalInteractableStep<OreVeinLocation
 
     @Override
     public void draw(double topX, double topY, float drawScale, double zoom) {
+        final Minecraft mc = Minecraft.getMinecraft();
+        final double scale = isXaero && shouldScale ? getScaling(zoom) : 1.0;
+        final double screenW = mc.displayWidth * scale;
+        final double screenH = mc.displayHeight * scale;
+        final double topMargin = (fontHeight + 5) * getFontScale() * scale;
+        if (topX + width < 0 || topX > screenW || topY + height < -topMargin || topY > screenH) {
+            return;
+        }
+
         if (zoom >= Config.minZoomLevelForOreLabel && !location.isDepleted()) {
             final int fontColor = location.drawSearchHighlight() ? 0xFFFFFF : 0x7F7F7F;
             DrawUtils.drawLabel(

--- a/src/main/java/com/sinthoras/visualprospecting/integration/model/render/UndergroundFluidRenderStep.java
+++ b/src/main/java/com/sinthoras/visualprospecting/integration/model/render/UndergroundFluidRenderStep.java
@@ -1,5 +1,6 @@
 package com.sinthoras.visualprospecting.integration.model.render;
 
+import net.minecraft.client.Minecraft;
 import net.minecraft.client.resources.I18n;
 
 import com.gtnewhorizons.navigator.api.model.steps.UniversalRenderStep;
@@ -19,6 +20,13 @@ public class UndergroundFluidRenderStep extends UniversalRenderStep<UndergroundF
 
     @Override
     public void draw(double topX, double topY, float drawScale, double zoom) {
+        final Minecraft mc = Minecraft.getMinecraft();
+        final double regionW = VP.undergroundFluidSizeChunkX * VP.chunkWidth * blockSize;
+        final double regionH = VP.undergroundFluidSizeChunkZ * VP.chunkWidth * blockSize;
+        if (topX + regionW < 0 || topY + regionH < 0 || topX > mc.displayWidth || topY > mc.displayHeight) {
+            return;
+        }
+
         renderChunks(topX, topY);
         setSize(VP.undergroundFluidSizeChunkX * VP.chunkWidth);
         int alpha = location.isActive() ? 255 : 74;

--- a/src/main/java/com/sinthoras/visualprospecting/integration/model/render/UndergroundFluidRenderStep.java
+++ b/src/main/java/com/sinthoras/visualprospecting/integration/model/render/UndergroundFluidRenderStep.java
@@ -73,46 +73,42 @@ public class UndergroundFluidRenderStep extends UniversalRenderStep<UndergroundF
         }
         final boolean drawLabels = zoomStep >= Config.minZoomLevelForUndergroundFluidDetails;
 
+        final int minProduction = location.getMinProduction();
+        final int maxProduction = location.getMaxProduction();
+        final int fluidColor = location.getFluid().getColor();
+        final int[][] chunks = location.getChunks();
+        final float productionRange = maxProduction - minProduction + 1;
+
+        final Minecraft mc = Minecraft.getMinecraft();
+        final double screenW = mc.displayWidth;
+        final double screenH = mc.displayHeight;
         setSize(VP.chunkWidth);
+        final double cellW = getAdjustedWidth();
+        final double cellH = getAdjustedHeight();
         for (int chunkX = 0; chunkX < VP.undergroundFluidSizeChunkX; chunkX++) {
+            final double cellX = x + chunkX * cellW;
+            if (cellX + cellW < 0 || cellX > screenW) continue;
             for (int chunkZ = 0; chunkZ < VP.undergroundFluidSizeChunkZ; chunkZ++) {
-                double xOffset = chunkX * getAdjustedWidth();
-                double yOffset = chunkZ * getAdjustedHeight();
-                int amount = location.getChunks()[chunkX][chunkZ];
-                if (amount > 0) {
-                    float alpha = (float) (amount - location.getMinProduction())
-                            / (location.getMaxProduction() - location.getMinProduction() + 1);
-                    alpha = alpha * 255;
-                    int fluidColor = location.getFluid().getColor();
-                    DrawUtils.drawRect(
-                            x + xOffset,
-                            y + yOffset,
-                            getAdjustedWidth(),
-                            getAdjustedHeight(),
-                            fluidColor,
-                            (int) alpha);
+                final double cellY = y + chunkZ * cellH;
+                if (cellY + cellH < 0 || cellY > screenH) continue;
+                int amount = chunks[chunkX][chunkZ];
+                if (amount <= 0) continue;
+                int alpha = (int) ((amount - minProduction) / productionRange * 255);
+                DrawUtils.drawRect(cellX, cellY, cellW, cellH, fluidColor, alpha);
 
-                    if (amount >= location.getMaxProduction()) {
-                        DrawUtils.drawHollowRect(
-                                x + xOffset,
-                                y + yOffset,
-                                getAdjustedWidth(),
-                                getAdjustedHeight(),
-                                0xFFD700,
-                                204,
-                                1.5);
-                    }
+                if (amount >= maxProduction) {
+                    DrawUtils.drawHollowRect(cellX, cellY, cellW, cellH, 0xFFD700, 204, 1.5);
+                }
 
-                    if (drawLabels) {
-                        DrawUtils.drawLabel(
-                                getFluidAmountFormatted(amount),
-                                x + xOffset + getAdjustedWidth() / 2,
-                                y + yOffset + getAdjustedHeight() / 2,
-                                0xFFFFFFFF,
-                                0xB4000000,
-                                true,
-                                getFontScale());
-                    }
+                if (drawLabels) {
+                    DrawUtils.drawLabel(
+                            getFluidAmountFormatted(amount),
+                            cellX + cellW / 2,
+                            cellY + cellH / 2,
+                            0xFFFFFFFF,
+                            0xB4000000,
+                            true,
+                            getFontScale());
                 }
             }
         }

--- a/src/main/java/com/sinthoras/visualprospecting/integration/model/render/UndergroundFluidRenderStep.java
+++ b/src/main/java/com/sinthoras/visualprospecting/integration/model/render/UndergroundFluidRenderStep.java
@@ -66,10 +66,12 @@ public class UndergroundFluidRenderStep extends UniversalRenderStep<UndergroundF
     }
 
     private void renderChunks(double x, double y) {
-        if (getZoomStep() < Config.minZoomLevelForUndergroundFluidDetails || location.getMaxProduction() <= 0
+        final double zoomStep = getZoomStep();
+        if (zoomStep < Config.minZoomLevelForUndergroundFluidDetails - 1 || location.getMaxProduction() <= 0
                 || !location.isActive()) {
             return;
         }
+        final boolean drawLabels = zoomStep >= Config.minZoomLevelForUndergroundFluidDetails;
 
         setSize(VP.chunkWidth);
         for (int chunkX = 0; chunkX < VP.undergroundFluidSizeChunkX; chunkX++) {
@@ -101,14 +103,16 @@ public class UndergroundFluidRenderStep extends UniversalRenderStep<UndergroundF
                                 1.5);
                     }
 
-                    DrawUtils.drawLabel(
-                            getFluidAmountFormatted(amount),
-                            x + xOffset + getAdjustedWidth() / 2,
-                            y + yOffset + getAdjustedHeight() / 2,
-                            0xFFFFFFFF,
-                            0xB4000000,
-                            true,
-                            getFontScale());
+                    if (drawLabels) {
+                        DrawUtils.drawLabel(
+                                getFluidAmountFormatted(amount),
+                                x + xOffset + getAdjustedWidth() / 2,
+                                y + yOffset + getAdjustedHeight() / 2,
+                                0xFFFFFFFF,
+                                0xB4000000,
+                                true,
+                                getFontScale());
+                    }
                 }
             }
         }


### PR DESCRIPTION
Currently trying to see ore or fluids on the map severely affect framerate if you zoom enough to render labels.

Attempts to fix this:
- Add culling to both view plus another extra tier of culling on the fluid cells
- Change default conf for minzoomlevel for labbels. Because at 1 ore labels overlap anyway (plus you can use search bar). And for fluid because of next change
- For fluid cells added an intermediate zoom level (1 under the minZoomLevelForUndergroundFluidDetails) where it show color gradiant without labels:

| Before | After |
|----------|----------|
| <img width="411" height="415" alt="image" src="https://github.com/user-attachments/assets/678577a7-e6f3-45fc-92f3-3b063fdce303" /> | <img width="363" height="387" alt="image" src="https://github.com/user-attachments/assets/ba15f9ae-7ba9-484f-a94d-54bd3caca9f6" />  |



Result: lot less FPS impact now, I can't see it anymore on ore vein, and only a little bit on fluids.