### PR TITLE
Few more changes to fluid overlay

### DIFF
--- a/src/main/java/com/sinthoras/visualprospecting/database/UndergroundFluidPosition.java
+++ b/src/main/java/com/sinthoras/visualprospecting/database/UndergroundFluidPosition.java
@@ -18,6 +18,8 @@ public class UndergroundFluidPosition {
     public final int chunkZ;
     public final Fluid fluid;
     public final int[][] chunks;
+    private final int minProduction;
+    private final int maxProduction;
 
     public UndergroundFluidPosition(int dimensionId, int chunkX, int chunkZ, Fluid fluid, int[][] chunks) {
         this.dimensionId = dimensionId;
@@ -25,6 +27,23 @@ public class UndergroundFluidPosition {
         this.chunkZ = Utils.mapToCornerUndergroundFluidChunkCoord(chunkZ);
         this.fluid = fluid;
         this.chunks = chunks;
+
+        int smallest = Integer.MAX_VALUE;
+        int largest = Integer.MIN_VALUE;
+        if (chunks != null) {
+            for (int cx = 0; cx < VP.undergroundFluidSizeChunkX; cx++) {
+                for (int cz = 0; cz < VP.undergroundFluidSizeChunkZ; cz++) {
+                    int amount = chunks[cx][cz];
+                    if (amount < smallest) smallest = amount;
+                    if (amount > largest) largest = amount;
+                }
+            }
+        } else {
+            smallest = 0;
+            largest = 0;
+        }
+        this.minProduction = smallest;
+        this.maxProduction = largest;
     }
 
     public int getBlockX() {
@@ -36,27 +55,11 @@ public class UndergroundFluidPosition {
     }
 
     public int getMinProduction() {
-        int smallest = Integer.MAX_VALUE;
-        for (int chunkX = 0; chunkX < VP.undergroundFluidSizeChunkX; chunkX++) {
-            for (int chunkZ = 0; chunkZ < VP.undergroundFluidSizeChunkZ; chunkZ++) {
-                if (chunks[chunkX][chunkZ] < smallest) {
-                    smallest = chunks[chunkX][chunkZ];
-                }
-            }
-        }
-        return smallest;
+        return minProduction;
     }
 
     public int getMaxProduction() {
-        int largest = Integer.MIN_VALUE;
-        for (int chunkX = 0; chunkX < VP.undergroundFluidSizeChunkX; chunkX++) {
-            for (int chunkZ = 0; chunkZ < VP.undergroundFluidSizeChunkZ; chunkZ++) {
-                if (chunks[chunkX][chunkZ] > largest) {
-                    largest = chunks[chunkX][chunkZ];
-                }
-            }
-        }
-        return largest;
+        return maxProduction;
     }
 
     public boolean isProspected() {

--- a/src/main/java/com/sinthoras/visualprospecting/integration/model/locations/UndergroundFluidLocation.java
+++ b/src/main/java/com/sinthoras/visualprospecting/integration/model/locations/UndergroundFluidLocation.java
@@ -1,17 +1,46 @@
 package com.sinthoras.visualprospecting.integration.model.locations;
 
 import net.minecraftforge.fluids.Fluid;
+import net.minecraftforge.fluids.FluidRegistry;
 
 import com.gtnewhorizons.navigator.api.model.locations.ILocationProvider;
 import com.sinthoras.visualprospecting.database.UndergroundFluidPosition;
 
+import gregtech.api.enums.UndergroundFluidNames;
+import it.unimi.dsi.fastutil.objects.Reference2IntMap;
+import it.unimi.dsi.fastutil.objects.Reference2IntOpenHashMap;
+
 public class UndergroundFluidLocation implements ILocationProvider {
 
+    private static final int NO_OVERRIDE = Integer.MIN_VALUE;
+    private static Reference2IntMap<Fluid> renderColorOverrides;
+
     private final UndergroundFluidPosition undergroundFluidPosition;
+    private final int color;
     private boolean active;
 
     public UndergroundFluidLocation(UndergroundFluidPosition undergroundFluidPosition) {
         this.undergroundFluidPosition = undergroundFluidPosition;
+        this.color = resolveColor(undergroundFluidPosition.fluid);
+    }
+
+    public static int resolveColor(Fluid fluid) {
+        if (fluid == null) return 0xFFFFFF;
+        if (renderColorOverrides == null) {
+            Reference2IntOpenHashMap<Fluid> map = new Reference2IntOpenHashMap<>();
+            map.defaultReturnValue(NO_OVERRIDE);
+            for (UndergroundFluidNames entry : UndergroundFluidNames.values()) {
+                if (entry.renderColor == null) continue;
+                Fluid f = FluidRegistry.getFluid(entry.name);
+                if (f == null) continue;
+                int packed = ((entry.renderColor[0] & 0xFF) << 16) | ((entry.renderColor[1] & 0xFF) << 8)
+                        | (entry.renderColor[2] & 0xFF);
+                map.put(f, packed);
+            }
+            renderColorOverrides = map;
+        }
+        int override = renderColorOverrides.getInt(fluid);
+        return override != NO_OVERRIDE ? override : fluid.getColor();
     }
 
     @Override
@@ -43,6 +72,10 @@ public class UndergroundFluidLocation implements ILocationProvider {
 
     public Fluid getFluid() {
         return undergroundFluidPosition.fluid;
+    }
+
+    public int getColor() {
+        return color;
     }
 
     public void setActive(boolean active) {

--- a/src/main/java/com/sinthoras/visualprospecting/integration/model/render/UndergroundFluidRenderStep.java
+++ b/src/main/java/com/sinthoras/visualprospecting/integration/model/render/UndergroundFluidRenderStep.java
@@ -76,6 +76,7 @@ public class UndergroundFluidRenderStep extends UniversalRenderStep<UndergroundF
         final int fluidColor = location.getColor();
         final int[][] chunks = location.getChunks();
         final float productionRange = maxProduction - minProduction + 1;
+        final boolean highlightPeak = maxProduction >= 10;
 
         final Minecraft mc = Minecraft.getMinecraft();
         final double screenW = mc.displayWidth;
@@ -91,10 +92,10 @@ public class UndergroundFluidRenderStep extends UniversalRenderStep<UndergroundF
                 if (cellY + cellH < 0 || cellY > screenH) continue;
                 int amount = chunks[chunkX][chunkZ];
                 if (amount <= 0) continue;
-                int alpha = (int) ((amount - minProduction) / productionRange * 255);
+                int alpha = productionRange > 1 ? (int) ((amount - minProduction) / productionRange * 255) : 10;
                 DrawUtils.drawRect(cellX, cellY, cellW, cellH, fluidColor, alpha);
 
-                if (amount >= maxProduction) {
+                if (highlightPeak && amount >= maxProduction) {
                     DrawUtils.drawHollowRect(cellX, cellY, cellW, cellH, 0xFFD700, 204, 1.5);
                 }
 

--- a/src/main/java/com/sinthoras/visualprospecting/integration/model/render/UndergroundFluidRenderStep.java
+++ b/src/main/java/com/sinthoras/visualprospecting/integration/model/render/UndergroundFluidRenderStep.java
@@ -29,11 +29,16 @@ public class UndergroundFluidRenderStep extends UniversalRenderStep<UndergroundF
 
         renderChunks(topX, topY);
         setSize(VP.undergroundFluidSizeChunkX * VP.chunkWidth);
-        int alpha = location.isActive() ? 255 : 74;
-        DrawUtils.drawHollowRect(topX, topY, getAdjustedWidth(), getAdjustedHeight(), location.getColor(), alpha, 2);
+        final int maxAmountInField = location.getMaxProduction();
+        if (maxAmountInField > 0) {
+            int alpha = location.isActive() ? 255 : 74;
+            DrawUtils
+                    .drawHollowRect(topX, topY, getAdjustedWidth(), getAdjustedHeight(), location.getColor(), alpha, 2);
+        } else {
+            DrawUtils.drawHollowRect(topX, topY, getAdjustedWidth(), getAdjustedHeight(), 0xFFFFFF, 74, 2);
+        }
 
         if (!isMinimap()) {
-            final int maxAmountInField = location.getMaxProduction();
             String label = I18n.format("visualprospecting.empty");
             if (maxAmountInField > 0) {
                 label = location.getMinProduction() + "L - "

--- a/src/main/java/com/sinthoras/visualprospecting/integration/model/render/UndergroundFluidRenderStep.java
+++ b/src/main/java/com/sinthoras/visualprospecting/integration/model/render/UndergroundFluidRenderStep.java
@@ -30,14 +30,7 @@ public class UndergroundFluidRenderStep extends UniversalRenderStep<UndergroundF
         renderChunks(topX, topY);
         setSize(VP.undergroundFluidSizeChunkX * VP.chunkWidth);
         int alpha = location.isActive() ? 255 : 74;
-        DrawUtils.drawHollowRect(
-                topX,
-                topY,
-                getAdjustedWidth(),
-                getAdjustedHeight() - 0.5,
-                location.getFluid().getColor(),
-                alpha,
-                2);
+        DrawUtils.drawHollowRect(topX, topY, getAdjustedWidth(), getAdjustedHeight(), location.getColor(), alpha, 2);
 
         if (!isMinimap()) {
             final int maxAmountInField = location.getMaxProduction();
@@ -75,7 +68,7 @@ public class UndergroundFluidRenderStep extends UniversalRenderStep<UndergroundF
 
         final int minProduction = location.getMinProduction();
         final int maxProduction = location.getMaxProduction();
-        final int fluidColor = location.getFluid().getColor();
+        final int fluidColor = location.getColor();
         final int[][] chunks = location.getChunks();
         final float productionRange = maxProduction - minProduction + 1;
 

--- a/src/main/java/com/sinthoras/visualprospecting/integration/voxelmap/VoxelMapEventHandler.java
+++ b/src/main/java/com/sinthoras/visualprospecting/integration/voxelmap/VoxelMapEventHandler.java
@@ -12,6 +12,7 @@ import com.sinthoras.visualprospecting.Utils;
 import com.sinthoras.visualprospecting.database.OreVeinPosition;
 import com.sinthoras.visualprospecting.database.UndergroundFluidPosition;
 import com.sinthoras.visualprospecting.hooks.ProspectingNotificationEvent;
+import com.sinthoras.visualprospecting.integration.model.locations.UndergroundFluidLocation;
 
 import cpw.mods.fml.common.eventhandler.SubscribeEvent;
 
@@ -50,7 +51,7 @@ public class VoxelMapEventHandler {
         UndergroundFluidPosition pos = event.getPosition();
         int x = Utils.coordChunkToBlock(pos.chunkX);
         int z = Utils.coordChunkToBlock(pos.chunkZ);
-        int color = pos.fluid.getColor();
+        int color = UndergroundFluidLocation.resolveColor(pos.fluid);
         TreeSet<Integer> dim = new TreeSet<>();
         dim.add(pos.dimensionId);
 


### PR DESCRIPTION
Follow up to #89

- Cache in/max production as suggested by @Worive in previous PR
- For colours it was actually always getting a fixed one from vanilla. Fixed that, also cache it.
- Small adjustments to fix minor visual bugs and annoyances that became more visible with the new colours.

How it looks now:
<img width="2560" height="1369" alt="2026-05-31_13 35 35" src="https://github.com/user-attachments/assets/3c3df168-d09f-4d9d-bf55-d086a50aa054" />
<img width="2560" height="1369" alt="2026-05-31_13 35 43" src="https://github.com/user-attachments/assets/bc191bce-5857-424f-9229-d67154d20e14" />

Colours come from: [github.com/GTNewHorizons/GT5-Unofficial/blob/master/src/main/java/gregtech/api/enums/UndergroundFluidNames.java](https://github.com/GTNewHorizons/GT5-Unofficial/blob/master/src/main/java/gregtech/api/enums/UndergroundFluidNames.java) (same as with the prospecting tools)
