### PR TITLE
Rewrote most logic behind /vp_recache (reconstruct server cache by scanning world files)

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -1,7 +1,9 @@
 dependencies {
     api('com.github.GTNewHorizons:Navigator:1.1.3:dev')
-    api('com.github.GTNewHorizons:GTNHLib:0.10.6:dev')
-    api('com.github.GTNewHorizons:GT5-Unofficial:5.09.52.548:dev')
+    api('com.github.GTNewHorizons:GTNHLib:0.11.4:dev')
+    api('com.github.GTNewHorizons:GT5-Unofficial:5.09.52.579:dev')
+
+    compileOnlyApi('com.github.GTNewHorizons:Galacticraft:3.4.28-GTNH:dev') { transitive = false }
 
     runtimeOnlyNonPublishable(rfg.deobf('maven.modrinth:journeymap:5.2.16'))
 }

--- a/src/main/java/com/sinthoras/visualprospecting/Config.java
+++ b/src/main/java/com/sinthoras/visualprospecting/Config.java
@@ -20,7 +20,7 @@ public class Config {
         public static final int uploadBandwidthBytes = 2000000;
         public static final int maxTransferCacheSizeMB = 50;
         public static final boolean enableVoxelMapWaypointsByDefault = false;
-        public static final int maxDimensionSizeMBForFastScanning = 10000;
+        public static final int maxRegionRowFileMBForInMemoryScan = 10000;
     }
 
     private static class Categories {
@@ -43,7 +43,7 @@ public class Config {
     public static int uploadPacketsPerSecond = uploadBandwidthBytes / VP.uploadSizePerPacketInBytes;
     public static int maxTransferCacheSizeMB = Defaults.maxTransferCacheSizeMB;
     public static boolean enableVoxelMapWaypointsByDefault = Defaults.enableVoxelMapWaypointsByDefault;
-    public static int maxDimensionSizeMBForFastScanning = Defaults.maxDimensionSizeMBForFastScanning;
+    public static int maxRegionRowFileMBForInMemoryScan = Defaults.maxRegionRowFileMBForInMemoryScan;
 
     public static void syncronizeConfiguration(File configFile) {
         Configuration configuration = new Configuration(configFile);
@@ -134,14 +134,13 @@ public class Config {
                 "[CLIENT / VoxelMap] Enable waypoints added by prospecting GT ore veins or underground fluids by default");
         enableVoxelMapWaypointsByDefault = enableVoxelMapWaypointsByDefaultProperty.getBoolean();
 
-        Property maxDimensionSizeMBForFastScanningProperty = configuration.get(
+        Property maxRegionRowFileMBForInMemoryScanProperty = configuration.get(
                 Categories.caching,
-                "maxDimensionSizeMBForFastScanning",
-                Defaults.maxDimensionSizeMBForFastScanning,
-                "[Client + Server] Define the maximum size of a "
-                        + "dimension in MB that can be processed in a single pass. Reduce this number if you run into "
-                        + "memory issues during the initial world scan (OutOfMemoryException).");
-        maxDimensionSizeMBForFastScanning = maxDimensionSizeMBForFastScanningProperty.getInt();
+                "maxRegionRowFileMBForInMemoryScan",
+                Defaults.maxRegionRowFileMBForInMemoryScan,
+                "[CLIENT + SERVER] Limit total region file size the recache vein job can keep open at once. "
+                        + "This is about size on disk and not actual RAM usage. Reduce this if you get a OutOfMemoryException during recache.");
+        maxRegionRowFileMBForInMemoryScan = maxRegionRowFileMBForInMemoryScanProperty.getInt();
 
         if (configuration.hasChanged()) {
             configuration.save();

--- a/src/main/java/com/sinthoras/visualprospecting/database/DimensionCache.java
+++ b/src/main/java/com/sinthoras/visualprospecting/database/DimensionCache.java
@@ -3,6 +3,7 @@ package com.sinthoras.visualprospecting.database;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -371,10 +372,23 @@ public class DimensionCache {
             markDirty();
             return UpdateResult.New;
         }
+
+        // Stop update if lower trusted VeinSource
+        if (!oreVeinPosition.getSource().canOverwrite(storedOreVeinPosition.getSource())) {
+            return UpdateResult.AlreadyKnown;
+        }
+
         if (storedOreVeinPosition.veinType != oreVeinPosition.veinType) {
             oreChunks.put(key, oreVeinPosition.joinDepletedState(storedOreVeinPosition));
             markDirty();
             return UpdateResult.New;
+        }
+
+        // If identical entry but "better" source we update it
+        if (storedOreVeinPosition.getSourceByte() != oreVeinPosition.getSourceByte()) {
+            oreChunks.put(key, oreVeinPosition.joinDepletedState(storedOreVeinPosition));
+            markDirty();
+            return UpdateResult.Updated;
         }
         return UpdateResult.AlreadyKnown;
     }
@@ -426,6 +440,14 @@ public class DimensionCache {
      * respective endChunks.
      */
     public void clearOreVeins(int startChunkX, int startChunkZ, int endChunkX, int endChunkZ) {
+        clearOreVeins(startChunkX, startChunkZ, endChunkX, endChunkZ, EnumSet.noneOf(VeinSource.class));
+    }
+
+    /**
+     * Reset selected veins within the area whose source is not in {@code protectedSources}.
+     */
+    public void clearOreVeins(int startChunkX, int startChunkZ, int endChunkX, int endChunkZ,
+            EnumSet<VeinSource> protectedSources) {
         // This method iterates for each chunk mapped. In many cases, it is probably faster to iterate over chunks in
         // the area to be cleared instead. i.e. if (chunksInClearArea < totalChunksMapped) {useAltIterator()}. If
         // someone calls this enough to make it a problem, they can add that.
@@ -433,8 +455,20 @@ public class DimensionCache {
             OreVeinPosition val = entry.getValue();
             final boolean withinX = val.chunkX >= startChunkX && val.chunkX <= endChunkX;
             final boolean withinZ = val.chunkZ >= startChunkZ && val.chunkZ <= endChunkZ;
-            return withinX && withinZ;
+            if (!withinX || !withinZ) return false;
+            return !protectedSources.contains(val.getSource());
         });
+        if (removedAny) {
+            markDirty();
+        }
+    }
+
+    /**
+     * Remove all ore veins from this dimension whose source is not in {@code protectedSources}.
+     */
+    public void clearOreVeinsExcept(EnumSet<VeinSource> protectedSources) {
+        boolean removedAny = oreChunks.long2ObjectEntrySet()
+                .removeIf(entry -> !protectedSources.contains(entry.getValue().getSource()));
         if (removedAny) {
             markDirty();
         }

--- a/src/main/java/com/sinthoras/visualprospecting/database/OreVeinPosition.java
+++ b/src/main/java/com/sinthoras/visualprospecting/database/OreVeinPosition.java
@@ -33,7 +33,7 @@ public class OreVeinPosition {
         this.chunkZ = Utils.mapToCenterOreChunkCoord(chunkZ);
         this.veinType = veinType;
         this.depleted = depleted;
-        this.source = (byte) source.ordinal();
+        this.source = source.toByte();
     }
 
     public int getBlockX() {

--- a/src/main/java/com/sinthoras/visualprospecting/database/VeinSource.java
+++ b/src/main/java/com/sinthoras/visualprospecting/database/VeinSource.java
@@ -1,24 +1,23 @@
 package com.sinthoras.visualprospecting.database;
 
 /**
- * Introduced for v3 of the server/client cache format.<br/>
- * Store value as {@code byte} for tinier footprint.<br/>
- * <br/>
- * <b>APPEND ONLY</b>, reordering or inserting values will silently corrupt existing data.
+ * Added for v3 of the server/client cache format. Stored as a {@code byte} for tinier footprint.
+ * <p>
+ * <b>Never change or reuse the {@code id} of an existing constant</b>, it would silently corrupt existing caches.
  */
 public enum VeinSource {
 
-    UNKNOWN(0),
-    GENERATED(3),
-    RESCAN(1),
-    API(2);
-    // Add new values here not anywhere else. Arg is trust hierarchy for overwriting.
-    // Trust order: GENERATED > API > RESCAN > UNKNOWN
+    // id = byte on disk to match to this enum | trustLevel = trust hierarchy for overwriting
+    UNKNOWN(0, 0),
+    RESCAN(2, 1),
+    API(3, 2),
+    GENERATED(1, 3);
 
-    private static final VeinSource[] VALUES = values();
+    private final int id;
     private final int trustLevel;
 
-    VeinSource(int trustLevel) {
+    VeinSource(int id, int trustLevel) {
+        this.id = id;
         this.trustLevel = trustLevel;
     }
 
@@ -26,10 +25,23 @@ public enum VeinSource {
         return this.trustLevel >= existing.trustLevel;
     }
 
-    public static VeinSource fromByte(byte ordinal) {
-        if (ordinal >= 0 && ordinal < VALUES.length) {
-            return VALUES[ordinal];
+    public byte toByte() {
+        return (byte) id;
+    }
+
+    private static final VeinSource[] BY_ID;
+    static {
+        int maxId = 0;
+        for (VeinSource source : values()) {
+            maxId = Math.max(maxId, source.id);
         }
-        return UNKNOWN;
+        BY_ID = new VeinSource[maxId + 1];
+        for (VeinSource source : values()) {
+            BY_ID[source.id] = source;
+        }
+    }
+
+    public static VeinSource fromByte(byte id) {
+        return ((id >= 0) && (id < BY_ID.length) && (BY_ID[id] != null)) ? BY_ID[id] : UNKNOWN;
     }
 }

--- a/src/main/java/com/sinthoras/visualprospecting/database/VeinSource.java
+++ b/src/main/java/com/sinthoras/visualprospecting/database/VeinSource.java
@@ -8,13 +8,23 @@ package com.sinthoras.visualprospecting.database;
  */
 public enum VeinSource {
 
-    UNKNOWN,
-    GENERATED,
-    RESCAN,
-    API;
-    // Add new values here not anywhere else
+    UNKNOWN(0),
+    GENERATED(3),
+    RESCAN(1),
+    API(2);
+    // Add new values here not anywhere else. Arg is trust hierarchy for overwriting.
+    // Trust order: GENERATED > API > RESCAN > UNKNOWN
 
     private static final VeinSource[] VALUES = values();
+    private final int trustLevel;
+
+    VeinSource(int trustLevel) {
+        this.trustLevel = trustLevel;
+    }
+
+    public boolean canOverwrite(VeinSource existing) {
+        return this.trustLevel >= existing.trustLevel;
+    }
 
     public static VeinSource fromByte(byte ordinal) {
         if (ordinal >= 0 && ordinal < VALUES.length) {

--- a/src/main/java/com/sinthoras/visualprospecting/database/WorldCache.java
+++ b/src/main/java/com/sinthoras/visualprospecting/database/WorldCache.java
@@ -2,6 +2,7 @@ package com.sinthoras.visualprospecting.database;
 
 import java.io.File;
 import java.nio.ByteBuffer;
+import java.util.EnumSet;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
@@ -104,6 +105,15 @@ public abstract class WorldCache {
     }
 
     /**
+     * Remove ore-vein entries across all dimensions whose source is not in {@code protectedSources}.
+     */
+    public void resetExcept(EnumSet<VeinSource> protectedSources) {
+        for (DimensionCache dim : dimensions.values()) {
+            dim.clearOreVeinsExcept(protectedSources);
+        }
+    }
+
+    /**
      * Reset some chunks. Not all, and (usually) not none - but some. Input coords are in chunk coordinates, NOT block
      * coords.
      *
@@ -114,16 +124,26 @@ public abstract class WorldCache {
      * @param endZ   The Z coord of the ending chunk.
      */
     public void resetSome(int dimID, int startX, int startZ, int endX, int endZ) {
+        resetSome(dimID, startX, startZ, endX, endZ, EnumSet.noneOf(VeinSource.class));
+    }
 
+    /**
+     * Same as {@link #resetSome(int, int, int, int, int)} but preserves entries whose source is in
+     * {@code protectedSources}.
+     */
+    public void resetSome(int dimID, int startX, int startZ, int endX, int endZ, EnumSet<VeinSource> protectedSources) {
         DimensionCache dim = dimensions.get(dimID);
         if (dim != null) {
-            dim.clearOreVeins(startX, startZ, endX, endZ);
+            dim.clearOreVeins(startX, startZ, endX, endZ, protectedSources);
             isLoaded = false;
         }
     }
 
     public void resetSpawnChunks(ChunkCoordinates spawn, int dimID) {
+        resetSpawnChunks(spawn, dimID, EnumSet.noneOf(VeinSource.class));
+    }
 
+    public void resetSpawnChunks(ChunkCoordinates spawn, int dimID, EnumSet<VeinSource> protectedSources) {
         int spawnChunkX = Utils.coordBlockToChunk(spawn.posX);
         int spawnChunkZ = Utils.coordBlockToChunk(spawn.posZ);
 
@@ -133,7 +153,7 @@ public abstract class WorldCache {
         int endX = spawnChunkX + spawnChunksRadius;
         int endZ = spawnChunkZ + spawnChunksRadius;
 
-        resetSome(dimID, startX, startZ, endX, endZ);
+        resetSome(dimID, startX, startZ, endX, endZ, protectedSources);
     }
 
     protected DimensionCache.UpdateResult putOreVein(final OreVeinPosition oreVeinPosition) {

--- a/src/main/java/com/sinthoras/visualprospecting/database/cachebuilder/AnalysisProgressTracker.java
+++ b/src/main/java/com/sinthoras/visualprospecting/database/cachebuilder/AnalysisProgressTracker.java
@@ -31,17 +31,9 @@ public class AnalysisProgressTracker {
         updateLog();
     }
 
-    public static synchronized void announceFastDimension(int dimensionId) {
-        final String message = "Processing dimension with id " + dimensionId + " with fast scanning.";
-        VP.info(message);
-        if (Utils.isLogicalClient()) {
-            ((MinecraftServerAccessor) MinecraftServer.getServer()).setUserMessage(message);
-        }
-    }
-
-    public static synchronized void announceSlowDimension(int dimensionId) {
-        final String message = "Processing dimension with id " + dimensionId + " with slow (safe) scanning.";
-        VP.info(message);
+    public static synchronized void announceDimension(int dimensionId) {
+        final String message = "Processing dimension with id " + dimensionId + ".";
+        VP.LOG.info(message);
         if (Utils.isLogicalClient()) {
             ((MinecraftServerAccessor) MinecraftServer.getServer()).setUserMessage(message);
         }
@@ -68,7 +60,7 @@ public class AnalysisProgressTracker {
                     + ")  "
                     + (numberOfRegionFiles == 0 ? 0 : ((regionFilesProcessed * 100) / numberOfRegionFiles))
                     + "%";
-            VP.info(message);
+            VP.LOG.info(message);
             if (Utils.isLogicalClient()) {
                 // Escape % for String.format
                 ((MinecraftServerAccessor) MinecraftServer.getServer()).setUserMessage(message + "%");
@@ -84,7 +76,7 @@ public class AnalysisProgressTracker {
         final String message = "Parsing complete! Thank you for your patience.  - Duration: "
                 + format.format(elapsedTimeMS / 1000)
                 + "sec";
-        VP.info(message);
+        VP.LOG.info(message);
         if (Utils.isLogicalClient()) {
             ((MinecraftServerAccessor) MinecraftServer.getServer()).setUserMessage(message);
         }
@@ -92,7 +84,7 @@ public class AnalysisProgressTracker {
 
     public static synchronized void notifyCorruptFile(File regionFile) {
         final String message = "Encountered corrupt/malformed/modified save file: " + regionFile;
-        VP.info(message);
+        VP.LOG.info(message);
         if (Utils.isLogicalClient()) {
             ((MinecraftServerAccessor) MinecraftServer.getServer()).setUserMessage(message);
         }

--- a/src/main/java/com/sinthoras/visualprospecting/database/cachebuilder/ChunkAnalysis.java
+++ b/src/main/java/com/sinthoras/visualprospecting/database/cachebuilder/ChunkAnalysis.java
@@ -5,14 +5,12 @@ import com.sinthoras.visualprospecting.database.veintypes.VeinType;
 import com.sinthoras.visualprospecting.database.veintypes.VeinTypeCaching;
 
 import gregtech.api.interfaces.IOreMaterial;
-import it.unimi.dsi.fastutil.objects.ObjectOpenHashSet;
-import it.unimi.dsi.fastutil.objects.ObjectSet;
 import it.unimi.dsi.fastutil.objects.Reference2IntOpenHashMap;
 
 // A slim, but faster version to identify >90% of veins
 public class ChunkAnalysis {
 
-    private final ObjectSet<VeinType> matchedVeins = new ObjectOpenHashSet<>();
+    private VeinType matchedVein = VeinType.NO_VEIN;
     private final Reference2IntOpenHashMap<IOreMaterial> oreCounts = new Reference2IntOpenHashMap<>();
     private int minVeinBlockY = VP.minecraftWorldHeight;
     private IOreMaterial mostCommonOre;
@@ -45,18 +43,18 @@ public class ChunkAnalysis {
         if (oreCounts.size() > 4) return false;
         for (VeinType vein : VeinTypeCaching.getVeinTypesForOre(mostCommonOre)) {
             if (vein.containsAllFoundOres(oreCounts.keySet(), dimName, mostCommonOre, minVeinBlockY)) {
-                matchedVeins.add(vein);
+                if (matchedVein != VeinType.NO_VEIN) {
+                    return false;
+                }
+                matchedVein = vein;
             }
         }
-        return matchedVeins.size() == 1;
+        return matchedVein != VeinType.NO_VEIN;
     }
 
     // Result only valid if matchesSingleVein() returned true
     public VeinType getMatchedVein() {
-        if (matchedVeins.isEmpty()) {
-            return VeinType.NO_VEIN;
-        }
-        return matchedVeins.iterator().next();
+        return matchedVein;
     }
 
     public int getVeinBlockY() {

--- a/src/main/java/com/sinthoras/visualprospecting/database/cachebuilder/ChunkAnalysis.java
+++ b/src/main/java/com/sinthoras/visualprospecting/database/cachebuilder/ChunkAnalysis.java
@@ -53,7 +53,7 @@ public class ChunkAnalysis {
                 .filter(vein -> vein.containsAllFoundOres(oreCounts.keySet(), dimName, mostCommonOre, minVeinBlockY))
                 .forEach(matchedVeins::add);
         // spotless:on
-        return matchedVeins.size() <= 1;
+        return matchedVeins.size() == 1;
     }
 
     // Result only valid if matchesSingleVein() returned true

--- a/src/main/java/com/sinthoras/visualprospecting/database/cachebuilder/ChunkAnalysis.java
+++ b/src/main/java/com/sinthoras/visualprospecting/database/cachebuilder/ChunkAnalysis.java
@@ -1,9 +1,5 @@
 package com.sinthoras.visualprospecting.database.cachebuilder;
 
-import java.util.Comparator;
-import java.util.Map;
-import java.util.stream.Collectors;
-
 import com.sinthoras.visualprospecting.VP;
 import com.sinthoras.visualprospecting.database.veintypes.VeinType;
 import com.sinthoras.visualprospecting.database.veintypes.VeinTypeCaching;
@@ -35,24 +31,23 @@ public class ChunkAnalysis {
             }
         });
 
-        // spotless:off
-        var byCount = oreCounts.reference2IntEntrySet()
-            .stream()
-            .sorted(Map.Entry.comparingByValue(Comparator.reverseOrder()))
-            .collect(Collectors.toList());
-        // spotless:on
-
-        if (!byCount.isEmpty()) mostCommonOre = byCount.get(0).getKey();
+        int highestOreCount = -1;
+        for (var entry : oreCounts.reference2IntEntrySet()) {
+            if (entry.getIntValue() > highestOreCount) {
+                highestOreCount = entry.getIntValue();
+                mostCommonOre = entry.getKey();
+            }
+        }
     }
 
     public boolean matchesSingleVein() {
         if (oreCounts.isEmpty()) return true;
         if (oreCounts.size() > 4) return false;
-        // spotless:off
-        VeinTypeCaching.getVeinTypes().stream()
-                .filter(vein -> vein.containsAllFoundOres(oreCounts.keySet(), dimName, mostCommonOre, minVeinBlockY))
-                .forEach(matchedVeins::add);
-        // spotless:on
+        for (VeinType vein : VeinTypeCaching.getVeinTypesForOre(mostCommonOre)) {
+            if (vein.containsAllFoundOres(oreCounts.keySet(), dimName, mostCommonOre, minVeinBlockY)) {
+                matchedVeins.add(vein);
+            }
+        }
         return matchedVeins.size() == 1;
     }
 

--- a/src/main/java/com/sinthoras/visualprospecting/database/cachebuilder/DetailedChunkAnalysis.java
+++ b/src/main/java/com/sinthoras/visualprospecting/database/cachebuilder/DetailedChunkAnalysis.java
@@ -1,9 +1,7 @@
 package com.sinthoras.visualprospecting.database.cachebuilder;
 
-import java.util.Comparator;
 import java.util.HashSet;
 import java.util.Map;
-import java.util.Optional;
 import java.util.Set;
 import java.util.stream.IntStream;
 
@@ -27,6 +25,10 @@ public class DetailedChunkAnalysis {
     private final Reference2IntOpenHashMap<IOreMaterial>[] oresPerY = new Reference2IntOpenHashMap[VP.minecraftWorldHeight];
     private final String dimName;
 
+    // Surrounding ore-chunk neighbours, to resolve overlap
+    private static final int[][] NEIGHBOR_OFFSETS = { { -3, 3 }, { 0, 3 }, { 3, 3 }, { 3, 0 }, { 3, -3 }, { 0, -3 },
+            { -3, -3 }, { -3, 0 } };
+
     public DetailedChunkAnalysis(int dimensionId, String dimName, int chunkX, int chunkZ) {
         this.dimensionId = dimensionId;
         this.chunkX = chunkX;
@@ -45,56 +47,18 @@ public class DetailedChunkAnalysis {
     }
 
     public void cleanUpWithNeighbors(final Map<Long, Integer> veinChunkY) {
-        final OreVeinPosition[] neighbors = new OreVeinPosition[] {
-                ServerCache.instance.getOreVein(dimensionId, chunkX - 3, chunkZ + 3),
-                ServerCache.instance.getOreVein(dimensionId, chunkX, chunkZ + 3),
-                ServerCache.instance.getOreVein(dimensionId, chunkX + 3, chunkZ + 3),
-                ServerCache.instance.getOreVein(dimensionId, chunkX + 3, chunkZ),
-                ServerCache.instance.getOreVein(dimensionId, chunkX + 3, chunkZ - 3),
-                ServerCache.instance.getOreVein(dimensionId, chunkX, chunkZ - 3),
-                ServerCache.instance.getOreVein(dimensionId, chunkX - 3, chunkZ - 3),
-                ServerCache.instance.getOreVein(dimensionId, chunkX - 3, chunkZ) };
-        final int[] neighborVeinBlockY = new int[] {
-                veinChunkY.getOrDefault(
-                        Utils.chunkCoordsToKey(
-                                Utils.mapToCenterOreChunkCoord(chunkX - 3),
-                                Utils.mapToCenterOreChunkCoord(chunkZ + 3)),
-                        0),
-                veinChunkY.getOrDefault(
-                        Utils.chunkCoordsToKey(
-                                Utils.mapToCenterOreChunkCoord(chunkX),
-                                Utils.mapToCenterOreChunkCoord(chunkZ + 3)),
-                        0),
-                veinChunkY.getOrDefault(
-                        Utils.chunkCoordsToKey(
-                                Utils.mapToCenterOreChunkCoord(chunkX + 3),
-                                Utils.mapToCenterOreChunkCoord(chunkZ + 3)),
-                        0),
-                veinChunkY.getOrDefault(
-                        Utils.chunkCoordsToKey(
-                                Utils.mapToCenterOreChunkCoord(chunkX + 3),
-                                Utils.mapToCenterOreChunkCoord(chunkZ)),
-                        0),
-                veinChunkY.getOrDefault(
-                        Utils.chunkCoordsToKey(
-                                Utils.mapToCenterOreChunkCoord(chunkX + 3),
-                                Utils.mapToCenterOreChunkCoord(chunkZ - 3)),
-                        0),
-                veinChunkY.getOrDefault(
-                        Utils.chunkCoordsToKey(
-                                Utils.mapToCenterOreChunkCoord(chunkX),
-                                Utils.mapToCenterOreChunkCoord(chunkZ - 3)),
-                        0),
-                veinChunkY.getOrDefault(
-                        Utils.chunkCoordsToKey(
-                                Utils.mapToCenterOreChunkCoord(chunkX - 3),
-                                Utils.mapToCenterOreChunkCoord(chunkZ - 3)),
-                        0),
-                veinChunkY.getOrDefault(
-                        Utils.chunkCoordsToKey(
-                                Utils.mapToCenterOreChunkCoord(chunkX - 3),
-                                Utils.mapToCenterOreChunkCoord(chunkZ)),
-                        0) };
+        final OreVeinPosition[] neighbors = new OreVeinPosition[NEIGHBOR_OFFSETS.length];
+        final int[] neighborVeinBlockY = new int[NEIGHBOR_OFFSETS.length];
+        for (int neighborId = 0; neighborId < NEIGHBOR_OFFSETS.length; neighborId++) {
+            final int neighborChunkX = chunkX + NEIGHBOR_OFFSETS[neighborId][0];
+            final int neighborChunkZ = chunkZ + NEIGHBOR_OFFSETS[neighborId][1];
+            neighbors[neighborId] = ServerCache.instance.getOreVein(dimensionId, neighborChunkX, neighborChunkZ);
+            neighborVeinBlockY[neighborId] = veinChunkY.getOrDefault(
+                    Utils.chunkCoordsToKey(
+                            Utils.mapToCenterOreChunkCoord(neighborChunkX),
+                            Utils.mapToCenterOreChunkCoord(neighborChunkZ)),
+                    0);
+        }
 
         // Remove all generated ores from neighbors. They could also be generated in the same chunk,
         // but that case is rare and therefore, neglected
@@ -142,18 +106,19 @@ public class DetailedChunkAnalysis {
 
         if (allOres.isEmpty()) return VeinType.NO_VEIN;
 
-        // spotless:off
-        final Optional<IOreMaterial> dominantOre = allOres.reference2IntEntrySet()
-            .stream()
-            .sorted(Map.Entry.comparingByValue(Comparator.reverseOrder()))
-            .map(Map.Entry::getKey)
-            .findFirst();
-        // spotless:on
+        IOreMaterial dominantOre = null;
+        int highestOreCount = -1;
+        for (var entry : allOres.reference2IntEntrySet()) {
+            if (entry.getIntValue() > highestOreCount) {
+                highestOreCount = entry.getIntValue();
+                dominantOre = entry.getKey();
+            }
+        }
 
-        if (!dominantOre.isPresent()) return VeinType.NO_VEIN;
+        if (dominantOre == null) return VeinType.NO_VEIN;
 
-        for (VeinType veinType : VeinTypeCaching.getVeinTypes()) {
-            if (veinType.matchesWithSpecificPrimaryOrSecondary(allOres.keySet(), dimName, dominantOre.get())) {
+        for (VeinType veinType : VeinTypeCaching.getVeinTypesForOre(dominantOre)) {
+            if (veinType.matchesWithSpecificPrimaryOrSecondary(allOres.keySet(), dimName, dominantOre)) {
                 matchedVeins.add(veinType);
             }
         }

--- a/src/main/java/com/sinthoras/visualprospecting/database/cachebuilder/DetailedChunkAnalysis.java
+++ b/src/main/java/com/sinthoras/visualprospecting/database/cachebuilder/DetailedChunkAnalysis.java
@@ -1,7 +1,5 @@
 package com.sinthoras.visualprospecting.database.cachebuilder;
 
-import java.util.HashSet;
-import java.util.Map;
 import java.util.Set;
 import java.util.stream.IntStream;
 
@@ -13,6 +11,9 @@ import com.sinthoras.visualprospecting.database.veintypes.VeinType;
 import com.sinthoras.visualprospecting.database.veintypes.VeinTypeCaching;
 
 import gregtech.api.interfaces.IOreMaterial;
+import it.unimi.dsi.fastutil.longs.Long2IntMap;
+import it.unimi.dsi.fastutil.objects.ObjectOpenHashSet;
+import it.unimi.dsi.fastutil.objects.ObjectSet;
 import it.unimi.dsi.fastutil.objects.Reference2IntOpenHashMap;
 
 // Slower, but more sophisticated approach to identify overlapping veins
@@ -24,6 +25,7 @@ public class DetailedChunkAnalysis {
     // For each height we count how often a ore (short) has occured
     private final Reference2IntOpenHashMap<IOreMaterial>[] oresPerY = new Reference2IntOpenHashMap[VP.minecraftWorldHeight];
     private final String dimName;
+    private VeinType resolvedVeinType = VeinType.NO_VEIN;
 
     // Surrounding ore-chunk neighbours, to resolve overlap
     private static final int[][] NEIGHBOR_OFFSETS = { { -3, 3 }, { 0, 3 }, { 3, 3 }, { 3, 0 }, { 3, -3 }, { 0, -3 },
@@ -46,24 +48,30 @@ public class DetailedChunkAnalysis {
         });
     }
 
-    public void cleanUpWithNeighbors(final Map<Long, Integer> veinChunkY) {
-        final OreVeinPosition[] neighbors = new OreVeinPosition[NEIGHBOR_OFFSETS.length];
-        final int[] neighborVeinBlockY = new int[NEIGHBOR_OFFSETS.length];
-        for (int neighborId = 0; neighborId < NEIGHBOR_OFFSETS.length; neighborId++) {
-            final int neighborChunkX = chunkX + NEIGHBOR_OFFSETS[neighborId][0];
-            final int neighborChunkZ = chunkZ + NEIGHBOR_OFFSETS[neighborId][1];
-            neighbors[neighborId] = ServerCache.instance.getOreVein(dimensionId, neighborChunkX, neighborChunkZ);
-            neighborVeinBlockY[neighborId] = veinChunkY.getOrDefault(
-                    Utils.chunkCoordsToKey(
-                            Utils.mapToCenterOreChunkCoord(neighborChunkX),
-                            Utils.mapToCenterOreChunkCoord(neighborChunkZ)),
-                    0);
-        }
+    // Resolve chunk vein against its neighbours and cache the result.
+    public void resolve(final Long2IntMap veinChunkY) {
+        cleanUpWithNeighbors(veinChunkY);
+        resolvedVeinType = getMatchedVein();
+    }
 
-        // Remove all generated ores from neighbors. They could also be generated in the same chunk,
-        // but that case is rare and therefore, neglected
-        for (int neighborId = 0; neighborId < neighbors.length; neighborId++) {
-            final OreVeinPosition neighbor = neighbors[neighborId];
+    public VeinType getResolvedVeinType() {
+        return resolvedVeinType;
+    }
+
+    private void cleanUpWithNeighbors(final Long2IntMap veinChunkY) {
+        // Remove ores that spilled over from neighbouring veins.
+        for (int[] neighborOffset : NEIGHBOR_OFFSETS) {
+            final int neighborChunkX = chunkX + neighborOffset[0];
+            final int neighborChunkZ = chunkZ + neighborOffset[1];
+
+            final long neighborKey = Utils.chunkCoordsToKey(
+                    Utils.mapToCenterOreChunkCoord(neighborChunkX),
+                    Utils.mapToCenterOreChunkCoord(neighborChunkZ));
+            if (!veinChunkY.containsKey(neighborKey)) continue;
+            final int neighborVeinBlockY = veinChunkY.get(neighborKey);
+
+            final OreVeinPosition neighbor = ServerCache.instance
+                    .getOreVein(dimensionId, neighborChunkX, neighborChunkZ);
             if (neighbor.veinType == VeinType.NO_VEIN) continue;
 
             final boolean atCoordinateAxis = Math.abs(neighbor.chunkX - chunkX) < 3
@@ -71,28 +79,23 @@ public class DetailedChunkAnalysis {
             final boolean canOverlap = atCoordinateAxis
                     ? neighbor.veinType.canOverlapIntoNeighborOreChunkAtCoordinateAxis()
                     : neighbor.veinType.canOverlapIntoNeighborOreChunk();
-            if (canOverlap) {
-                final int veinBlockY = neighborVeinBlockY[neighborId];
+            if (!canOverlap) continue;
 
-                for (int layerBlockY = 0; layerBlockY < VeinType.veinHeight; layerBlockY++) {
-                    final int blockY = veinBlockY + layerBlockY;
+            for (int layerBlockY = 0; layerBlockY < VeinType.veinHeight; layerBlockY++) {
+                final int blockY = neighborVeinBlockY + layerBlockY;
+                if (blockY > 255) break;
 
-                    if (blockY > 255) {
-                        break;
-                    }
-
-                    if (oresPerY[blockY] != null) {
-                        for (IOreMaterial ore : neighbor.veinType.getOresAtLayer(layerBlockY)) {
-                            oresPerY[blockY].removeInt(ore);
-                        }
+                if (oresPerY[blockY] != null) {
+                    for (IOreMaterial ore : neighbor.veinType.getOresAtLayer(layerBlockY)) {
+                        oresPerY[blockY].removeInt(ore);
                     }
                 }
             }
         }
     }
 
-    public VeinType getMatchedVein() {
-        final Set<VeinType> matchedVeins = new HashSet<>();
+    private VeinType getMatchedVein() {
+        final ObjectSet<VeinType> matchedVeins = new ObjectOpenHashSet<>();
 
         final Reference2IntOpenHashMap<IOreMaterial> allOres = new Reference2IntOpenHashMap<>();
 
@@ -125,16 +128,27 @@ public class DetailedChunkAnalysis {
 
         if (matchedVeins.size() == 1) {
             return matchedVeins.iterator().next();
-        } else if (matchedVeins.size() >= 2) {
+        }
+        if (matchedVeins.size() >= 2) {
             matchedVeins.removeIf(
                     veinType -> IntStream.range(veinType.minBlockY, veinType.maxBlockY)
                             .noneMatch(blockY -> isOreVeinGeneratedAtHeight(veinType, blockY)));
+            return matchedVeins.size() == 1 ? matchedVeins.iterator().next() : VeinType.NO_VEIN;
+        }
+        return matchIgnoringSporadic(allOres.keySet(), dominantOre);
+    }
 
-            if (matchedVeins.size() == 1) {
-                return matchedVeins.iterator().next();
+    private VeinType matchIgnoringSporadic(Set<IOreMaterial> foundOres, IOreMaterial dominantOre) {
+        VeinType onlyMatch = VeinType.NO_VEIN;
+        for (VeinType veinType : VeinTypeCaching.getVeinTypesForOre(dominantOre)) {
+            if (veinType.matchesIgnoringSporadic(foundOres, dimName, dominantOre)) {
+                if (onlyMatch != VeinType.NO_VEIN) {
+                    return VeinType.NO_VEIN;
+                }
+                onlyMatch = veinType;
             }
         }
-        return VeinType.NO_VEIN;
+        return onlyMatch;
     }
 
     private boolean isOreVeinGeneratedAtHeight(VeinType veinType, int blockY) {

--- a/src/main/java/com/sinthoras/visualprospecting/database/cachebuilder/DimensionAnalysis.java
+++ b/src/main/java/com/sinthoras/visualprospecting/database/cachebuilder/DimensionAnalysis.java
@@ -2,9 +2,12 @@ package com.sinthoras.visualprospecting.database.cachebuilder;
 
 import java.io.File;
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
+import java.util.List;
+import java.util.Queue;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.zip.DataFormatException;
 
@@ -22,12 +25,17 @@ import com.sinthoras.visualprospecting.database.veintypes.VeinType;
 
 import cpw.mods.fml.common.Optional;
 import gregtech.api.enums.Mods;
+import it.unimi.dsi.fastutil.ints.Int2ObjectAVLTreeMap;
+import it.unimi.dsi.fastutil.ints.Int2ObjectOpenHashMap;
+import it.unimi.dsi.fastutil.longs.Long2IntMap;
+import it.unimi.dsi.fastutil.longs.Long2IntOpenHashMap;
 import micdoodle8.mods.galacticraft.api.galaxies.CelestialBody;
 import micdoodle8.mods.galacticraft.api.prefab.world.gen.WorldProviderSpace;
 
 public class DimensionAnalysis {
 
     private static final Pattern REGION_FILE_NAME = Pattern.compile("^r\\.-?\\d+\\.-?\\d+\\.mca$");
+    private static final int INVALID_REGION_COORD = Integer.MIN_VALUE;
 
     public final int dimensionId;
     public final String dimensionName;
@@ -44,98 +52,197 @@ public class DimensionAnalysis {
 
     public void processMinecraftWorld(Collection<File> regionFiles) {
         if (regionFiles.isEmpty()) return;
-        final Map<Long, Integer> veinBlockY = new ConcurrentHashMap<>();
-        final long dimensionSizeMB = regionFiles.stream().mapToLong(File::length).sum() >> 20;
 
-        if (dimensionSizeMB <= Config.maxDimensionSizeMBForFastScanning) {
-            AnalysisProgressTracker.announceFastDimension(dimensionId);
-            AnalysisProgressTracker.setNumberOfRegionFiles(regionFiles.size());
+        AnalysisProgressTracker.announceDimension(dimensionId);
 
-            final Map<Long, DetailedChunkAnalysis> chunksForSecondIdentificationPass = new ConcurrentHashMap<>();
+        // Group region files by rows
+        final Int2ObjectAVLTreeMap<List<File>> regionFilesByRow = new Int2ObjectAVLTreeMap<>();
+        final List<File> malformedRegionFiles = new ArrayList<>();
+        for (File regionFile : regionFiles) {
+            final int regionZ = parseRegionZ(regionFile);
+            if (regionZ == INVALID_REGION_COORD) {
+                malformedRegionFiles.add(regionFile);
+            } else {
+                List<File> rowRegionFiles = regionFilesByRow.get(regionZ);
+                if (rowRegionFiles == null) {
+                    rowRegionFiles = new ArrayList<>();
+                    regionFilesByRow.put(regionZ, rowRegionFiles);
+                }
+                rowRegionFiles.add(regionFile);
+            }
+        }
 
-            regionFiles.parallelStream().forEach(regionFile -> {
-                executeForEachGeneratedOreChunk(regionFile, (chunk, chunkX, chunkZ) -> {
+        final long maxRowSizeMBForHolding = Config.maxRegionRowFileMBForInMemoryScan;
+        int totalRegionFilePasses = regionFiles.size() - malformedRegionFiles.size();
+        for (List<File> row : regionFilesByRow.values()) {
+            if (rowSizeMB(row) > maxRowSizeMBForHolding) {
+                totalRegionFilePasses += row.size();
+            }
+        }
+        AnalysisProgressTracker.setNumberOfRegionFiles(totalRegionFilePasses);
+
+        final Long2IntOpenHashMap veinBlockY = new Long2IntOpenHashMap();
+
+        // Get rid of region files with malformed names
+        for (File regionFile : malformedRegionFiles) {
+            executeForEachGeneratedOreChunk(regionFile, (chunk, chunkX, chunkZ) -> {});
+        }
+
+        final int[] rows = regionFilesByRow.keySet().toIntArray();
+        final Int2ObjectOpenHashMap<RegionRowResult> heldRows = new Int2ObjectOpenHashMap<>();
+        int rowToFinalize = 0;
+        for (int i = 0; i < rows.length; i++) {
+            final int regionZ = rows[i];
+            heldRows.put(regionZ, fastPassRow(regionFilesByRow.get(regionZ), veinBlockY, maxRowSizeMBForHolding));
+
+            // Once both below and above rows are processed it's safe to finalize the middle one.
+            while (rowToFinalize < i && rows[rowToFinalize] + 1 <= regionZ) {
+                finalizeRow(heldRows.remove(rows[rowToFinalize]), veinBlockY);
+                rowToFinalize++;
+            }
+        }
+        while (rowToFinalize < rows.length) {
+            finalizeRow(heldRows.remove(rows[rowToFinalize]), veinBlockY);
+            rowToFinalize++;
+        }
+    }
+
+    // Fast-pass one region row. write single vein match, hold on ambiguous matches for later.
+    private RegionRowResult fastPassRow(List<File> rowRegionFiles, Long2IntMap veinBlockY,
+            long maxRowSizeMBForHolding) {
+        final boolean holdInMemory = rowSizeMB(rowRegionFiles) <= maxRowSizeMBForHolding;
+        final Queue<PendingOreVein> singleMatches = new ConcurrentLinkedQueue<>();
+        final Queue<DetailedChunkAnalysis> ambiguousChunks = holdInMemory ? new ConcurrentLinkedQueue<>() : null;
+
+        rowRegionFiles.parallelStream()
+                .forEach(regionFile -> executeForEachGeneratedOreChunk(regionFile, (chunk, chunkX, chunkZ) -> {
                     final ChunkAnalysis analysis = new ChunkAnalysis(dimensionName);
                     analysis.processMinecraftChunk(chunk);
 
                     if (analysis.matchesSingleVein()) {
-                        ServerCache.instance.notifyOreVeinGeneration(
-                                dimensionId,
-                                chunkX,
-                                chunkZ,
-                                analysis.getMatchedVein(),
-                                VeinSource.RESCAN);
-                        veinBlockY.put(Utils.chunkCoordsToKey(chunkX, chunkZ), analysis.getVeinBlockY());
-                    } else {
+                        final VeinType veinType = analysis.getMatchedVein();
+                        if (veinType != VeinType.NO_VEIN) {
+                            singleMatches.add(new PendingOreVein(chunkX, chunkZ, veinType, analysis.getVeinBlockY()));
+                        }
+                    } else if (holdInMemory) {
                         final DetailedChunkAnalysis detailedChunk = new DetailedChunkAnalysis(
                                 dimensionId,
                                 dimensionName,
                                 chunkX,
                                 chunkZ);
                         detailedChunk.processMinecraftChunk(chunk);
-                        chunksForSecondIdentificationPass.put(Utils.chunkCoordsToKey(chunkX, chunkZ), detailedChunk);
+                        ambiguousChunks.add(detailedChunk);
                     }
-                });
-            });
+                }));
 
-            chunksForSecondIdentificationPass.values().parallelStream().forEach(chunk -> {
-                chunk.cleanUpWithNeighbors(veinBlockY);
+        for (PendingOreVein singleMatch : singleMatches) {
+            ServerCache.instance.notifyOreVeinGeneration(
+                    dimensionId,
+                    singleMatch.chunkX,
+                    singleMatch.chunkZ,
+                    singleMatch.veinType,
+                    VeinSource.RESCAN);
+            veinBlockY.put(Utils.chunkCoordsToKey(singleMatch.chunkX, singleMatch.chunkZ), singleMatch.veinBlockY);
+        }
+
+        return holdInMemory ? RegionRowResult.held(ambiguousChunks) : RegionRowResult.reRead(rowRegionFiles);
+    }
+
+    // Resolve a row's overlapping chunks against their neighbours
+    private void finalizeRow(RegionRowResult row, Long2IntMap veinBlockY) {
+        if (row == null) return;
+
+        if (row.heldAmbiguousChunks != null) {
+            row.heldAmbiguousChunks.parallelStream().forEach(detailedChunk -> detailedChunk.resolve(veinBlockY));
+            for (DetailedChunkAnalysis detailedChunk : row.heldAmbiguousChunks) {
                 ServerCache.instance.notifyOreVeinGeneration(
                         dimensionId,
-                        chunk.chunkX,
-                        chunk.chunkZ,
-                        chunk.getMatchedVein(),
+                        detailedChunk.chunkX,
+                        detailedChunk.chunkZ,
+                        detailedChunk.getResolvedVeinType(),
                         VeinSource.RESCAN);
-            });
+            }
         } else {
-            AnalysisProgressTracker.announceSlowDimension(dimensionId);
-            AnalysisProgressTracker.setNumberOfRegionFiles(regionFiles.size() * 2);
+            final Queue<PendingOreVein> resolved = new ConcurrentLinkedQueue<>();
+            row.rowRegionFiles.parallelStream()
+                    .forEach(regionFile -> executeForEachGeneratedOreChunk(regionFile, (chunk, chunkX, chunkZ) -> {
+                        if (ServerCache.instance.getOreVein(dimensionId, chunkX, chunkZ).veinType == VeinType.NO_VEIN) {
+                            final DetailedChunkAnalysis detailedChunk = new DetailedChunkAnalysis(
+                                    dimensionId,
+                                    dimensionName,
+                                    chunkX,
+                                    chunkZ);
+                            detailedChunk.processMinecraftChunk(chunk);
+                            detailedChunk.resolve(veinBlockY);
+                            if (detailedChunk.getResolvedVeinType() != VeinType.NO_VEIN) {
+                                resolved.add(
+                                        new PendingOreVein(chunkX, chunkZ, detailedChunk.getResolvedVeinType(), 0));
+                            }
+                        }
+                    }));
+            for (PendingOreVein result : resolved) {
+                ServerCache.instance.notifyOreVeinGeneration(
+                        dimensionId,
+                        result.chunkX,
+                        result.chunkZ,
+                        result.veinType,
+                        VeinSource.RESCAN);
+            }
+        }
+    }
 
-            regionFiles.parallelStream().forEach(regionFile -> {
-                executeForEachGeneratedOreChunk(regionFile, (chunk, chunkX, chunkZ) -> {
-                    final ChunkAnalysis analysis = new ChunkAnalysis(dimensionName);
-                    analysis.processMinecraftChunk(chunk);
+    private static int parseRegionZ(File regionFile) {
+        final Matcher matcher = REGION_FILE_NAME.matcher(regionFile.getName());
+        if (!matcher.matches()) return INVALID_REGION_COORD;
+        try {
+            return Integer.parseInt(regionFile.getName().split("\\.")[2]);
+        } catch (NumberFormatException ignored) {
+            return INVALID_REGION_COORD;
+        }
+    }
 
-                    if (analysis.matchesSingleVein()) {
-                        ServerCache.instance.notifyOreVeinGeneration(
-                                dimensionId,
-                                chunkX,
-                                chunkZ,
-                                analysis.getMatchedVein(),
-                                VeinSource.RESCAN);
-                        veinBlockY.put(Utils.chunkCoordsToKey(chunkX, chunkZ), analysis.getVeinBlockY());
-                    }
-                });
-            });
+    private static long rowSizeMB(List<File> regionFiles) {
+        return regionFiles.stream().mapToLong(File::length).sum() >> 20;
+    }
 
-            regionFiles.parallelStream().forEach(regionFile -> {
-                executeForEachGeneratedOreChunk(regionFile, (chunk, chunkX, chunkZ) -> {
-                    if (ServerCache.instance.getOreVein(dimensionId, chunkX, chunkZ).veinType == VeinType.NO_VEIN) {
-                        final DetailedChunkAnalysis detailedAnalysis = new DetailedChunkAnalysis(
-                                dimensionId,
-                                dimensionName,
-                                chunkX,
-                                chunkZ);
+    private static final class RegionRowResult {
 
-                        detailedAnalysis.processMinecraftChunk(chunk);
-                        detailedAnalysis.cleanUpWithNeighbors(veinBlockY);
+        private final Collection<DetailedChunkAnalysis> heldAmbiguousChunks;
+        private final List<File> rowRegionFiles;
 
-                        ServerCache.instance.notifyOreVeinGeneration(
-                                dimensionId,
-                                detailedAnalysis.chunkX,
-                                detailedAnalysis.chunkZ,
-                                detailedAnalysis.getMatchedVein(),
-                                VeinSource.RESCAN);
-                    }
-                });
-            });
+        private RegionRowResult(Collection<DetailedChunkAnalysis> heldAmbiguousChunks, List<File> rowRegionFiles) {
+            this.heldAmbiguousChunks = heldAmbiguousChunks;
+            this.rowRegionFiles = rowRegionFiles;
+        }
+
+        static RegionRowResult held(Collection<DetailedChunkAnalysis> heldAmbiguousChunks) {
+            return new RegionRowResult(heldAmbiguousChunks, null);
+        }
+
+        static RegionRowResult reRead(List<File> rowRegionFiles) {
+            return new RegionRowResult(null, rowRegionFiles);
+        }
+    }
+
+    private static final class PendingOreVein {
+
+        final int chunkX;
+        final int chunkZ;
+        final VeinType veinType;
+        final int veinBlockY;
+
+        PendingOreVein(int chunkX, int chunkZ, VeinType veinType, int veinBlockY) {
+            this.chunkX = chunkX;
+            this.chunkZ = chunkZ;
+            this.veinType = veinType;
+            this.veinBlockY = veinBlockY;
         }
     }
 
     private void executeForEachGeneratedOreChunk(File regionFile, IChunkHandler chunkHandler) {
         try {
             if (!REGION_FILE_NAME.matcher(regionFile.getName()).matches()) {
-                VP.warn("Invalid region file found! " + regionFile.getCanonicalPath() + " continuing");
+                VP.LOG.warn("Invalid region file found! {} continuing", regionFile.getCanonicalPath());
                 return;
             }
             final String[] parts = regionFile.getName().split("\\.");

--- a/src/main/java/com/sinthoras/visualprospecting/database/cachebuilder/DimensionAnalysis.java
+++ b/src/main/java/com/sinthoras/visualprospecting/database/cachebuilder/DimensionAnalysis.java
@@ -27,6 +27,8 @@ import micdoodle8.mods.galacticraft.api.prefab.world.gen.WorldProviderSpace;
 
 public class DimensionAnalysis {
 
+    private static final Pattern REGION_FILE_NAME = Pattern.compile("^r\\.-?\\d+\\.-?\\d+\\.mca$");
+
     public final int dimensionId;
     public final String dimensionName;
 
@@ -132,7 +134,7 @@ public class DimensionAnalysis {
 
     private void executeForEachGeneratedOreChunk(File regionFile, IChunkHandler chunkHandler) {
         try {
-            if (!Pattern.matches("^r\\.-?\\d+\\.-?\\d+\\.mca$", regionFile.getName())) {
+            if (!REGION_FILE_NAME.matcher(regionFile.getName()).matches()) {
                 VP.warn("Invalid region file found! " + regionFile.getCanonicalPath() + " continuing");
                 return;
             }

--- a/src/main/java/com/sinthoras/visualprospecting/database/cachebuilder/DimensionAnalysis.java
+++ b/src/main/java/com/sinthoras/visualprospecting/database/cachebuilder/DimensionAnalysis.java
@@ -16,6 +16,7 @@ import net.minecraft.world.WorldProvider;
 import net.minecraft.world.WorldServer;
 import net.minecraftforge.common.DimensionManager;
 
+import com.github.bsideup.jabel.Desugar;
 import com.sinthoras.visualprospecting.Config;
 import com.sinthoras.visualprospecting.Utils;
 import com.sinthoras.visualprospecting.VP;
@@ -205,15 +206,8 @@ public class DimensionAnalysis {
         return regionFiles.stream().mapToLong(File::length).sum() >> 20;
     }
 
-    private static final class RegionRowResult {
-
-        private final Collection<DetailedChunkAnalysis> heldAmbiguousChunks;
-        private final List<File> rowRegionFiles;
-
-        private RegionRowResult(Collection<DetailedChunkAnalysis> heldAmbiguousChunks, List<File> rowRegionFiles) {
-            this.heldAmbiguousChunks = heldAmbiguousChunks;
-            this.rowRegionFiles = rowRegionFiles;
-        }
+    @Desugar
+    private record RegionRowResult(Collection<DetailedChunkAnalysis> heldAmbiguousChunks, List<File> rowRegionFiles) {
 
         static RegionRowResult held(Collection<DetailedChunkAnalysis> heldAmbiguousChunks) {
             return new RegionRowResult(heldAmbiguousChunks, null);
@@ -224,19 +218,9 @@ public class DimensionAnalysis {
         }
     }
 
-    private static final class PendingOreVein {
+    @Desugar
+    private record PendingOreVein(int chunkX, int chunkZ, VeinType veinType, int veinBlockY) {
 
-        final int chunkX;
-        final int chunkZ;
-        final VeinType veinType;
-        final int veinBlockY;
-
-        PendingOreVein(int chunkX, int chunkZ, VeinType veinType, int veinBlockY) {
-            this.chunkX = chunkX;
-            this.chunkZ = chunkZ;
-            this.veinType = veinType;
-            this.veinBlockY = veinBlockY;
-        }
     }
 
     private void executeForEachGeneratedOreChunk(File regionFile, IChunkHandler chunkHandler) {

--- a/src/main/java/com/sinthoras/visualprospecting/database/cachebuilder/DimensionAnalysis.java
+++ b/src/main/java/com/sinthoras/visualprospecting/database/cachebuilder/DimensionAnalysis.java
@@ -20,6 +20,11 @@ import com.sinthoras.visualprospecting.database.ServerCache;
 import com.sinthoras.visualprospecting.database.VeinSource;
 import com.sinthoras.visualprospecting.database.veintypes.VeinType;
 
+import cpw.mods.fml.common.Optional;
+import gregtech.api.enums.Mods;
+import micdoodle8.mods.galacticraft.api.galaxies.CelestialBody;
+import micdoodle8.mods.galacticraft.api.prefab.world.gen.WorldProviderSpace;
+
 public class DimensionAnalysis {
 
     public final int dimensionId;
@@ -167,10 +172,32 @@ public class DimensionAnalysis {
         }
     }
 
+    // Resolves the dimension name which will help filter ore veins
     private String getDimensionName() {
-        WorldServer world = DimensionManager.getWorld(dimensionId);
-        if (world == null) return "";
-        WorldProvider provider = world.provider;
-        return provider == null ? "" : provider.getDimensionName();
+        final WorldServer world = DimensionManager.getWorld(dimensionId);
+        WorldProvider provider = world != null ? world.provider : null;
+        if (provider == null) {
+            try {
+                provider = DimensionManager.createProviderFor(dimensionId);
+            } catch (Throwable t) {
+                VP.LOG.warn("Could not resolve a provider for dimensionId={}: {}", dimensionId, t);
+                return "";
+            }
+        }
+
+        final String celestialName = Mods.GalacticraftCore.isModLoaded() ? getCelestialBodyName(provider) : null;
+        if (celestialName != null) return celestialName;
+
+        final String name = provider.getDimensionName();
+        return name == null ? "" : name;
+    }
+
+    @Optional.Method(modid = Mods.ModIDs.GALACTICRAFT_CORE)
+    private static String getCelestialBodyName(WorldProvider provider) {
+        if (provider instanceof WorldProviderSpace space) {
+            final CelestialBody body = space.getCelestialBody();
+            return body == null ? null : body.getName();
+        }
+        return null;
     }
 }

--- a/src/main/java/com/sinthoras/visualprospecting/database/cachebuilder/DimensionAnalysis.java
+++ b/src/main/java/com/sinthoras/visualprospecting/database/cachebuilder/DimensionAnalysis.java
@@ -65,12 +65,7 @@ public class DimensionAnalysis {
                 VP.LOG.warn("Invalid region file found! {} continuing", regionFile.getAbsolutePath());
                 malformedRegionFileCount++;
             } else {
-                List<File> rowRegionFiles = regionFilesByRow.get(regionZ);
-                if (rowRegionFiles == null) {
-                    rowRegionFiles = new ArrayList<>();
-                    regionFilesByRow.put(regionZ, rowRegionFiles);
-                }
-                rowRegionFiles.add(regionFile);
+                regionFilesByRow.computeIfAbsent(regionZ, value -> new ArrayList<>()).add(regionFile);
             }
         }
 

--- a/src/main/java/com/sinthoras/visualprospecting/database/cachebuilder/DimensionAnalysis.java
+++ b/src/main/java/com/sinthoras/visualprospecting/database/cachebuilder/DimensionAnalysis.java
@@ -144,6 +144,12 @@ public class DimensionAnalysis {
                         if (chunkX != Utils.mapToCenterOreChunkCoord(chunkX)) continue;
                         if (chunkZ != Utils.mapToCenterOreChunkCoord(chunkZ)) continue;
 
+                        // Skip chunks already cached with higher trustLevel than VeinSource.RESCAN
+                        if (!VeinSource.RESCAN.canOverwrite(
+                                ServerCache.instance.getOreVein(dimensionId, chunkX, chunkZ).getSource())) {
+                            continue;
+                        }
+
                         NBTTagCompound chunk = region.getChunk(localChunkX, localChunkZ);
 
                         if (chunk == null) continue;

--- a/src/main/java/com/sinthoras/visualprospecting/database/cachebuilder/DimensionAnalysis.java
+++ b/src/main/java/com/sinthoras/visualprospecting/database/cachebuilder/DimensionAnalysis.java
@@ -56,13 +56,14 @@ public class DimensionAnalysis {
 
         AnalysisProgressTracker.announceDimension(dimensionId);
 
-        // Group region files by rows
+        // Group region files by rows, skipping any with malformed names
         final Int2ObjectAVLTreeMap<List<File>> regionFilesByRow = new Int2ObjectAVLTreeMap<>();
-        final List<File> malformedRegionFiles = new ArrayList<>();
+        int malformedRegionFileCount = 0;
         for (File regionFile : regionFiles) {
             final int regionZ = parseRegionZ(regionFile);
             if (regionZ == INVALID_REGION_COORD) {
-                malformedRegionFiles.add(regionFile);
+                VP.LOG.warn("Invalid region file found! {} continuing", regionFile.getAbsolutePath());
+                malformedRegionFileCount++;
             } else {
                 List<File> rowRegionFiles = regionFilesByRow.get(regionZ);
                 if (rowRegionFiles == null) {
@@ -74,7 +75,7 @@ public class DimensionAnalysis {
         }
 
         final long maxRowSizeMBForHolding = Config.maxRegionRowFileMBForInMemoryScan;
-        int totalRegionFilePasses = regionFiles.size() - malformedRegionFiles.size();
+        int totalRegionFilePasses = regionFiles.size() - malformedRegionFileCount;
         for (List<File> row : regionFilesByRow.values()) {
             if (rowSizeMB(row) > maxRowSizeMBForHolding) {
                 totalRegionFilePasses += row.size();
@@ -83,11 +84,6 @@ public class DimensionAnalysis {
         AnalysisProgressTracker.setNumberOfRegionFiles(totalRegionFilePasses);
 
         final Long2IntOpenHashMap veinBlockY = new Long2IntOpenHashMap();
-
-        // Get rid of region files with malformed names
-        for (File regionFile : malformedRegionFiles) {
-            executeForEachGeneratedOreChunk(regionFile, (chunk, chunkX, chunkZ) -> {});
-        }
 
         final int[] rows = regionFilesByRow.keySet().toIntArray();
         final Int2ObjectOpenHashMap<RegionRowResult> heldRows = new Int2ObjectOpenHashMap<>();
@@ -225,10 +221,6 @@ public class DimensionAnalysis {
 
     private void executeForEachGeneratedOreChunk(File regionFile, IChunkHandler chunkHandler) {
         try {
-            if (!REGION_FILE_NAME.matcher(regionFile.getName()).matches()) {
-                VP.LOG.warn("Invalid region file found! {} continuing", regionFile.getCanonicalPath());
-                return;
-            }
             final String[] parts = regionFile.getName().split("\\.");
             final int regionChunkX = Integer.parseInt(parts[1]) << 5;
             final int regionChunkZ = Integer.parseInt(parts[2]) << 5;

--- a/src/main/java/com/sinthoras/visualprospecting/database/cachebuilder/PartiallyLoadedChunk.java
+++ b/src/main/java/com/sinthoras/visualprospecting/database/cachebuilder/PartiallyLoadedChunk.java
@@ -20,6 +20,7 @@ import gregtech.common.ores.BWOreAdapter;
 import gregtech.common.ores.GTOreAdapter;
 import gregtech.common.ores.OreInfo;
 import gregtech.common.ores.OreManager;
+import it.unimi.dsi.fastutil.ints.Int2IntFunction;
 import it.unimi.dsi.fastutil.ints.Int2ShortFunction;
 
 public class PartiallyLoadedChunk {
@@ -28,8 +29,9 @@ public class PartiallyLoadedChunk {
     private static final int BLOCKS_PER_EBS = SECTION_SIZE * SECTION_SIZE * SECTION_SIZE;
     public static final int CHUNK_HEIGHT = 256;
     private static final int SECTIONS_PER_CHUNK = CHUNK_HEIGHT / SECTION_SIZE;
+    private static final int NIBBLE_ARRAY_SIZE = BLOCKS_PER_EBS / 2; // Expected byte-array lengths for nibble arrays
 
-    private final Int2ShortFunction[] blocks = new Int2ShortFunction[SECTIONS_PER_CHUNK];
+    private final Int2IntFunction[] blocks = new Int2IntFunction[SECTIONS_PER_CHUNK];
     private final Int2ShortFunction[] metas = new Int2ShortFunction[SECTIONS_PER_CHUNK];
 
     private List<NBTTagCompound> tiles;
@@ -63,12 +65,15 @@ public class PartiallyLoadedChunk {
                 //
                 // "Add", "BlocksB2Hi", "BlocksB3", "Data1High", and "Data2" are all optional —
                 // absent arrays mean those bits are zero, preserving backwards compatibility.
+                // Reference:
+                // https://github.com/GTMEGA/EndlessIDs/blob/master/src/main/java/com/falsepattern/endlessids/managers/BlockIDManager.java
+                // https://github.com/GTMEGA/EndlessIDs/blob/master/src/main/java/com/falsepattern/endlessids/managers/BlockMetaManager.java
                 loadEndlessIds(section, chunkX, y, chunkZ);
 
             } else {
                 // Vanilla format or unrecognized: skip block data.
                 // Old chunks only have ore TileEntities.
-                this.blocks[y] = i -> (short) 0;
+                this.blocks[y] = i -> 0;
                 this.metas[y] = i -> (short) 0;
             }
         }
@@ -85,15 +90,14 @@ public class PartiallyLoadedChunk {
         ShortBuffer metas = ByteBuffer.wrap(section.getByteArray("Data16")).asShortBuffer();
 
         if (blocks.capacity() == 0 || metas.capacity() == 0) {
-            // no-op for empty sections
-            this.blocks[y] = i -> (short) 0;
+            this.blocks[y] = i -> 0;
             this.metas[y] = i -> (short) 0;
             return;
         }
 
         if (blocks.capacity() != BLOCKS_PER_EBS) {
             VP.LOG.error(
-                    "Corrupt section detected at X={}, Y={}, Z={} (Blocks16 length was {}, needs {})",
+                    "Corrupt NotEnoughIDs section at X={}, Y={}, Z={}: Blocks16 length {} (expected {})",
                     chunkX,
                     y,
                     chunkZ,
@@ -104,7 +108,7 @@ public class PartiallyLoadedChunk {
 
         if (metas.capacity() != BLOCKS_PER_EBS) {
             VP.LOG.error(
-                    "Corrupt section detected at X={}, Y={}, Z={} (Data16 length was {}, needs {})",
+                    "Corrupt NotEnoughIDs section at X={}, Y={}, Z={}: Data16 length {} (expected {})",
                     chunkX,
                     y,
                     chunkZ,
@@ -117,67 +121,109 @@ public class PartiallyLoadedChunk {
         this.metas[y] = metas::get;
     }
 
+    /**
+     * Loads a chunk section saved in EndlessIDs format. Missing optional arrays are treated as all-zero.
+     */
     private void loadEndlessIds(NBTTagCompound section, int chunkX, byte y, int chunkZ) {
+        // --- Block ID arrays ---
+        byte[] blocksRaw = section.getByteArray("Blocks");
+        if (blocksRaw.length != BLOCKS_PER_EBS) {
+            VP.LOG.error(
+                    "Corrupt EndlessIDs section at X={}, Y={}, Z={}: Blocks length {} (expected {})",
+                    chunkX,
+                    y,
+                    chunkZ,
+                    blocksRaw.length,
+                    BLOCKS_PER_EBS);
+            this.blocks[y] = i -> 0;
+            this.metas[y] = i -> (short) 0;
+            return;
+        }
+        ByteBuffer blockLo = ByteBuffer.wrap(blocksRaw);
 
-        // 00FF
-        ByteBuffer blocks1Byte = ByteBuffer.wrap(section.getByteArray("Blocks"));
-        // 0F00
-        ByteBuffer blocks2Lo;
-        if (section.hasKey("Add")) {
-            blocks2Lo = ByteBuffer.wrap(section.getByteArray("Add"));
-        } else {
-            blocks2Lo = null;
+        ByteBuffer blockMid = loadNibbleArray(section, "Add", chunkX, y, chunkZ);
+        ByteBuffer blockHi = loadNibbleArray(section, "BlocksB2Hi", chunkX, y, chunkZ);
+
+        // BlocksB3: bits 16-23, one byte per block, extends IDs to 24 bits
+        ByteBuffer blockB3 = null;
+        if (section.hasKey("BlocksB3")) {
+            byte[] b3 = section.getByteArray("BlocksB3");
+            if (b3.length != BLOCKS_PER_EBS) {
+                VP.LOG.error(
+                        "Corrupt EndlessIDs section at X={}, Y={}, Z={}: BlocksB3 length {} (expected {})",
+                        chunkX,
+                        y,
+                        chunkZ,
+                        b3.length,
+                        BLOCKS_PER_EBS);
+            } else {
+                blockB3 = ByteBuffer.wrap(b3);
+            }
         }
-        // F000
-        ByteBuffer blocks2Hi;
-        if (section.hasKey("BlocksB2Hi")) {
-            blocks2Hi = ByteBuffer.wrap(section.getByteArray("BlocksB2Hi"));
-        } else {
-            blocks2Hi = null;
-        }
+        final ByteBuffer fBlockB3 = blockB3;
 
         this.blocks[y] = i -> {
             int nibbleShift = (i & 1) * 4;
-            short id = (short) (blocks1Byte.get(i) & 0xFF);
-            if (blocks2Lo != null) {
-                id |= (short) (((blocks2Lo.get(i >> 1) >> nibbleShift) & 0xF) << 8);
-            }
-            if (blocks2Hi != null) {
-                id |= (short) (((blocks2Hi.get(i >> 1) >> nibbleShift) & 0xF) << 12);
-            }
+            int id = blockLo.get(i) & 0xFF;
+            if (blockMid != null) id |= ((blockMid.get(i >> 1) >> nibbleShift) & 0xF) << 8;
+            if (blockHi != null) id |= ((blockHi.get(i >> 1) >> nibbleShift) & 0xF) << 12;
+            if (fBlockB3 != null) id |= (fBlockB3.get(i) & 0xFF) << 16;
             return id;
         };
 
-        // 000F
-        ByteBuffer meta1Lo = ByteBuffer.wrap(section.getByteArray("Data"));
-        // 00F0
-        ByteBuffer meta1Hi;
-        if (section.hasKey("Data1High")) {
-            meta1Hi = ByteBuffer.wrap(section.getByteArray("Data1High"));
-        } else {
-            meta1Hi = null;
-        }
-        // FF00
-        ByteBuffer meta2;
+        // --- Meta arrays ---
+        ByteBuffer metaLo = loadNibbleArray(section, "Data", chunkX, y, chunkZ);
+        ByteBuffer metaMid = loadNibbleArray(section, "Data1High", chunkX, y, chunkZ);
+
+        ByteBuffer metaHi = null;
         if (section.hasKey("Data2")) {
-            meta2 = ByteBuffer.wrap(section.getByteArray("Data2"));
-        } else {
-            meta2 = null;
+            byte[] data2 = section.getByteArray("Data2");
+            if (data2.length != BLOCKS_PER_EBS) {
+                VP.LOG.error(
+                        "Corrupt EndlessIDs section at X={}, Y={}, Z={}: Data2 length {} (expected {})",
+                        chunkX,
+                        y,
+                        chunkZ,
+                        data2.length,
+                        BLOCKS_PER_EBS);
+            } else {
+                metaHi = ByteBuffer.wrap(data2);
+            }
         }
+
+        final ByteBuffer fMetaLo = metaLo;
+        final ByteBuffer fMetaMid = metaMid;
+        final ByteBuffer fMetaHi = metaHi;
 
         this.metas[y] = i -> {
             int nibbleShift = (i & 1) * 4;
             short meta = 0;
-            meta |= (short) (((meta1Lo.get(i >> 1) >> nibbleShift) & 0xF));
-            if (meta1Hi != null) {
-                meta |= (short) (((meta1Hi.get(i >> 1) >> nibbleShift) & 0xF) << 4);
-            }
-            if (meta2 != null) {
-                meta |= (short) ((meta2.get(i) & 0xFF) << 8);
-            }
+            if (fMetaLo != null) meta |= (short) ((fMetaLo.get(i >> 1) >> nibbleShift) & 0xF);
+            if (fMetaMid != null) meta |= (short) (((fMetaMid.get(i >> 1) >> nibbleShift) & 0xF) << 4);
+            if (fMetaHi != null) meta |= (short) ((fMetaHi.get(i) & 0xFF) << 8);
             return meta;
         };
+    }
 
+    /**
+     * Reads an optional nibble array from a section NBT compound. Validates the length ({@link #NIBBLE_ARRAY_SIZE}) and
+     * returns null if the key is absent or the array is malformed, so callers can treat null as all-zero bits.
+     */
+    private ByteBuffer loadNibbleArray(NBTTagCompound section, String key, int chunkX, byte y, int chunkZ) {
+        if (!section.hasKey(key)) return null;
+        byte[] data = section.getByteArray(key);
+        if (data.length != NIBBLE_ARRAY_SIZE) {
+            VP.LOG.error(
+                    "Corrupt EndlessIDs section at X={}, Y={}, Z={}: {} nibble array length {} (expected {})",
+                    chunkX,
+                    y,
+                    chunkZ,
+                    key,
+                    data.length,
+                    NIBBLE_ARRAY_SIZE);
+            return null;
+        }
+        return ByteBuffer.wrap(data);
     }
 
     public int getBlockId(int x, int y, int z) {
@@ -189,7 +235,7 @@ public class PartiallyLoadedChunk {
 
         int section = index / BLOCKS_PER_EBS;
 
-        Int2ShortFunction blocks = this.blocks[section];
+        Int2IntFunction blocks = this.blocks[section];
 
         if (blocks == null) return 0;
 

--- a/src/main/java/com/sinthoras/visualprospecting/database/cachebuilder/PartiallyLoadedChunk.java
+++ b/src/main/java/com/sinthoras/visualprospecting/database/cachebuilder/PartiallyLoadedChunk.java
@@ -21,7 +21,6 @@ import gregtech.common.ores.GTOreAdapter;
 import gregtech.common.ores.OreInfo;
 import gregtech.common.ores.OreManager;
 import it.unimi.dsi.fastutil.ints.Int2IntFunction;
-import it.unimi.dsi.fastutil.ints.Int2ShortFunction;
 
 public class PartiallyLoadedChunk {
 
@@ -32,7 +31,7 @@ public class PartiallyLoadedChunk {
     private static final int NIBBLE_ARRAY_SIZE = BLOCKS_PER_EBS / 2; // Expected byte-array lengths for nibble arrays
 
     private final Int2IntFunction[] blocks = new Int2IntFunction[SECTIONS_PER_CHUNK];
-    private final Int2ShortFunction[] metas = new Int2ShortFunction[SECTIONS_PER_CHUNK];
+    private final Int2IntFunction[] metas = new Int2IntFunction[SECTIONS_PER_CHUNK];
 
     private List<NBTTagCompound> tiles;
 
@@ -49,7 +48,7 @@ public class PartiallyLoadedChunk {
                 // NotEnoughIDs format: full 16-bit block IDs and metas stored as ShortBuffers.
                 loadNotEnoughIds(section, chunkX, y, chunkZ);
 
-            } else if (section.hasKey("Add") || section.hasKey("BlocksB2Hi")) {
+            } else if (section.hasKey("Add") || section.hasKey("BlocksB2Hi") || section.hasKey("Data1High")) {
                 // EndlessIDs format: block ID and meta split across multiple nibble/byte arrays.
                 //
                 // Block ID layout (24 bits total):
@@ -74,7 +73,7 @@ public class PartiallyLoadedChunk {
                 // Vanilla format or unrecognized: skip block data.
                 // Old chunks only have ore TileEntities.
                 this.blocks[y] = i -> 0;
-                this.metas[y] = i -> (short) 0;
+                this.metas[y] = i -> 0;
             }
         }
 
@@ -91,7 +90,7 @@ public class PartiallyLoadedChunk {
 
         if (blocks.capacity() == 0 || metas.capacity() == 0) {
             this.blocks[y] = i -> 0;
-            this.metas[y] = i -> (short) 0;
+            this.metas[y] = i -> 0;
             return;
         }
 
@@ -117,110 +116,71 @@ public class PartiallyLoadedChunk {
             return;
         }
 
-        this.blocks[y] = blocks::get;
-        this.metas[y] = metas::get;
+        // Mask with 0xFFFF to avoid sign extension when widening short -> int (IDs/metas >= 0x8000).
+        this.blocks[y] = i -> blocks.get(i) & 0xFFFF;
+        this.metas[y] = i -> metas.get(i) & 0xFFFF;
     }
 
     /**
-     * Loads a chunk section saved in EndlessIDs format. Missing optional arrays are treated as all-zero.
+     * Loads a chunk section saved in EndlessIDs format. "Blocks" and "Data" are mandatory; all other arrays are
+     * optional and treated as all-zero when absent. A corrupt mandatory array zeroes the whole section.
      */
     private void loadEndlessIds(NBTTagCompound section, int chunkX, byte y, int chunkZ) {
-        // --- Block ID arrays ---
-        byte[] blocksRaw = section.getByteArray("Blocks");
-        if (blocksRaw.length != BLOCKS_PER_EBS) {
+        ByteBuffer blockLo = loadOptionalArray(section, "Blocks", BLOCKS_PER_EBS, chunkX, y, chunkZ);
+        ByteBuffer metaLo = loadOptionalArray(section, "Data", NIBBLE_ARRAY_SIZE, chunkX, y, chunkZ);
+        if (blockLo == null || metaLo == null) {
             VP.LOG.error(
-                    "Corrupt EndlessIDs section at X={}, Y={}, Z={}: Blocks length {} (expected {})",
+                    "Corrupt EndlessIDs section at X={}, Y={}, Z={}: missing or invalid mandatory Blocks/Data array",
                     chunkX,
                     y,
-                    chunkZ,
-                    blocksRaw.length,
-                    BLOCKS_PER_EBS);
+                    chunkZ);
             this.blocks[y] = i -> 0;
-            this.metas[y] = i -> (short) 0;
+            this.metas[y] = i -> 0;
             return;
         }
-        ByteBuffer blockLo = ByteBuffer.wrap(blocksRaw);
 
-        ByteBuffer blockMid = loadNibbleArray(section, "Add", chunkX, y, chunkZ);
-        ByteBuffer blockHi = loadNibbleArray(section, "BlocksB2Hi", chunkX, y, chunkZ);
-
-        // BlocksB3: bits 16-23, one byte per block, extends IDs to 24 bits
-        ByteBuffer blockB3 = null;
-        if (section.hasKey("BlocksB3")) {
-            byte[] b3 = section.getByteArray("BlocksB3");
-            if (b3.length != BLOCKS_PER_EBS) {
-                VP.LOG.error(
-                        "Corrupt EndlessIDs section at X={}, Y={}, Z={}: BlocksB3 length {} (expected {})",
-                        chunkX,
-                        y,
-                        chunkZ,
-                        b3.length,
-                        BLOCKS_PER_EBS);
-            } else {
-                blockB3 = ByteBuffer.wrap(b3);
-            }
-        }
-        final ByteBuffer fBlockB3 = blockB3;
+        ByteBuffer blockMid = loadOptionalArray(section, "Add", NIBBLE_ARRAY_SIZE, chunkX, y, chunkZ);
+        ByteBuffer blockHi = loadOptionalArray(section, "BlocksB2Hi", NIBBLE_ARRAY_SIZE, chunkX, y, chunkZ);
+        ByteBuffer blockB3 = loadOptionalArray(section, "BlocksB3", BLOCKS_PER_EBS, chunkX, y, chunkZ);
 
         this.blocks[y] = i -> {
             int nibbleShift = (i & 1) * 4;
             int id = blockLo.get(i) & 0xFF;
             if (blockMid != null) id |= ((blockMid.get(i >> 1) >> nibbleShift) & 0xF) << 8;
             if (blockHi != null) id |= ((blockHi.get(i >> 1) >> nibbleShift) & 0xF) << 12;
-            if (fBlockB3 != null) id |= (fBlockB3.get(i) & 0xFF) << 16;
+            if (blockB3 != null) id |= (blockB3.get(i) & 0xFF) << 16;
             return id;
         };
 
-        // --- Meta arrays ---
-        ByteBuffer metaLo = loadNibbleArray(section, "Data", chunkX, y, chunkZ);
-        ByteBuffer metaMid = loadNibbleArray(section, "Data1High", chunkX, y, chunkZ);
-
-        ByteBuffer metaHi = null;
-        if (section.hasKey("Data2")) {
-            byte[] data2 = section.getByteArray("Data2");
-            if (data2.length != BLOCKS_PER_EBS) {
-                VP.LOG.error(
-                        "Corrupt EndlessIDs section at X={}, Y={}, Z={}: Data2 length {} (expected {})",
-                        chunkX,
-                        y,
-                        chunkZ,
-                        data2.length,
-                        BLOCKS_PER_EBS);
-            } else {
-                metaHi = ByteBuffer.wrap(data2);
-            }
-        }
-
-        final ByteBuffer fMetaLo = metaLo;
-        final ByteBuffer fMetaMid = metaMid;
-        final ByteBuffer fMetaHi = metaHi;
+        ByteBuffer metaMid = loadOptionalArray(section, "Data1High", NIBBLE_ARRAY_SIZE, chunkX, y, chunkZ);
+        ByteBuffer metaHi = loadOptionalArray(section, "Data2", BLOCKS_PER_EBS, chunkX, y, chunkZ);
 
         this.metas[y] = i -> {
             int nibbleShift = (i & 1) * 4;
-            short meta = 0;
-            if (fMetaLo != null) meta |= (short) ((fMetaLo.get(i >> 1) >> nibbleShift) & 0xF);
-            if (fMetaMid != null) meta |= (short) (((fMetaMid.get(i >> 1) >> nibbleShift) & 0xF) << 4);
-            if (fMetaHi != null) meta |= (short) ((fMetaHi.get(i) & 0xFF) << 8);
+            int meta = (metaLo.get(i >> 1) >> nibbleShift) & 0xF;
+            if (metaMid != null) meta |= ((metaMid.get(i >> 1) >> nibbleShift) & 0xF) << 4;
+            if (metaHi != null) meta |= (metaHi.get(i) & 0xFF) << 8;
             return meta;
         };
     }
 
     /**
-     * Reads an optional nibble array from a section NBT compound. Validates the length ({@link #NIBBLE_ARRAY_SIZE}) and
-     * returns null if the key is absent or the array is malformed, so callers can treat null as all-zero bits.
+     * Reads an optional byte array from a section NBT compound. Validates the length against {@code expectedLength} and
+     * returns null if the key is absent or the array is malformed.
      */
-    private ByteBuffer loadNibbleArray(NBTTagCompound section, String key, int chunkX, byte y, int chunkZ) {
+    private ByteBuffer loadOptionalArray(NBTTagCompound section, String key, int expectedLength, int chunkX, byte y,
+            int chunkZ) {
         if (!section.hasKey(key)) return null;
         byte[] data = section.getByteArray(key);
-        if (data.length != NIBBLE_ARRAY_SIZE) {
+        if (data.length != expectedLength) {
             VP.LOG.error(
-                    "Corrupt EndlessIDs section at X={}, Y={}, Z={}: {} nibble array length {} (expected {})",
+                    "Corrupt EndlessIDs section at X={}, Y={}, Z={}: {} length {} (expected {})",
                     chunkX,
                     y,
                     chunkZ,
                     key,
                     data.length,
-                    NIBBLE_ARRAY_SIZE);
+                    expectedLength);
             return null;
         }
         return ByteBuffer.wrap(data);
@@ -257,7 +217,7 @@ public class PartiallyLoadedChunk {
 
         int section = index / BLOCKS_PER_EBS;
 
-        Int2ShortFunction metas = this.metas[section];
+        Int2IntFunction metas = this.metas[section];
 
         if (metas == null) return 0;
 

--- a/src/main/java/com/sinthoras/visualprospecting/database/cachebuilder/PartiallyLoadedChunk.java
+++ b/src/main/java/com/sinthoras/visualprospecting/database/cachebuilder/PartiallyLoadedChunk.java
@@ -48,70 +48,26 @@ public class PartiallyLoadedChunk {
                 loadNotEnoughIds(section, chunkX, y, chunkZ);
 
             } else if (section.hasKey("Add") || section.hasKey("BlocksB2Hi")) {
-                // chunk saved with EndlessIds
-
-                // 00FF
-                ByteBuffer blocks1Byte = ByteBuffer.wrap(section.getByteArray("Blocks"));
-                // 0F00
-                ByteBuffer blocks2Lo;
-                if (section.hasKey("Add")) {
-                    blocks2Lo = ByteBuffer.wrap(section.getByteArray("Add"));
-                } else {
-                    blocks2Lo = null;
-                }
-                // F000
-                ByteBuffer blocks2Hi;
-                if (section.hasKey("BlocksB2Hi")) {
-                    blocks2Hi = ByteBuffer.wrap(section.getByteArray("BlocksB2Hi"));
-                } else {
-                    blocks2Hi = null;
-                }
-
-                this.blocks[y] = i -> {
-                    int nibbleShift = (i & 1) * 4;
-                    short id = (short) (blocks1Byte.get(i) & 0xFF);
-                    if (blocks2Lo != null) {
-                        id |= (short) (((blocks2Lo.get(i >> 1) >> nibbleShift) & 0xF) << 8);
-                    }
-                    if (blocks2Hi != null) {
-                        id |= (short) (((blocks2Hi.get(i >> 1) >> nibbleShift) & 0xF) << 12);
-                    }
-                    return id;
-                };
-
-                // 000F
-                ByteBuffer meta1Lo = ByteBuffer.wrap(section.getByteArray("Data"));
-                // 00F0
-                ByteBuffer meta1Hi;
-                if (section.hasKey("Data1High")) {
-                    meta1Hi = ByteBuffer.wrap(section.getByteArray("Data1High"));
-                } else {
-                    meta1Hi = null;
-                }
-                // FF00
-                ByteBuffer meta2;
-                if (section.hasKey("Data2")) {
-                    meta2 = ByteBuffer.wrap(section.getByteArray("Data2"));
-                } else {
-                    meta2 = null;
-                }
-
-                this.metas[y] = i -> {
-                    int nibbleShift = (i & 1) * 4;
-                    short meta = 0;
-                    meta |= (short) (((meta1Lo.get(i >> 1) >> nibbleShift) & 0xF));
-                    if (meta1Hi != null) {
-                        meta |= (short) (((meta1Hi.get(i >> 1) >> nibbleShift) & 0xF) << 4);
-                    }
-                    if (meta2 != null) {
-                        meta |= (short) ((meta2.get(i) & 0xFF) << 8);
-                    }
-                    return meta;
-                };
+                // EndlessIDs format: block ID and meta split across multiple nibble/byte arrays.
+                //
+                // Block ID layout (24 bits total):
+                // bits 0x0000FF — "Blocks" byte array (vanilla low 8 bits)
+                // bits 0x000F00 — "Add" nibble array (NotEnoughIDs extension to 12 bits)
+                // bits 0x00F000 — "BlocksB2Hi" nibble array (EndlessIDs extension to 16 bits)
+                // bits 0xFF0000 — "BlocksB3" byte array (EndlessIDs extension to 24 bits)
+                //
+                // Meta layout (16 bits total):
+                // bits 0x000F — "Data" nibble array (vanilla low 4 bits)
+                // bits 0x00F0 — "Data1High" nibble array (EndlessIDs extension)
+                // bits 0xFF00 — "Data2" byte array (EndlessIDs extension, 1 byte per block)
+                //
+                // "Add", "BlocksB2Hi", "BlocksB3", "Data1High", and "Data2" are all optional —
+                // absent arrays mean those bits are zero, preserving backwards compatibility.
+                loadEndlessIds(section, chunkX, y, chunkZ);
 
             } else {
-                // neither NotEnoughIds nor EndlessIds
-                // don't bother loading the actual blocks, if a chunk is this old it'll only have ore tiles
+                // Vanilla format or unrecognized: skip block data.
+                // Old chunks only have ore TileEntities.
                 this.blocks[y] = i -> (short) 0;
                 this.metas[y] = i -> (short) 0;
             }
@@ -159,6 +115,69 @@ public class PartiallyLoadedChunk {
 
         this.blocks[y] = blocks::get;
         this.metas[y] = metas::get;
+    }
+
+    private void loadEndlessIds(NBTTagCompound section, int chunkX, byte y, int chunkZ) {
+
+        // 00FF
+        ByteBuffer blocks1Byte = ByteBuffer.wrap(section.getByteArray("Blocks"));
+        // 0F00
+        ByteBuffer blocks2Lo;
+        if (section.hasKey("Add")) {
+            blocks2Lo = ByteBuffer.wrap(section.getByteArray("Add"));
+        } else {
+            blocks2Lo = null;
+        }
+        // F000
+        ByteBuffer blocks2Hi;
+        if (section.hasKey("BlocksB2Hi")) {
+            blocks2Hi = ByteBuffer.wrap(section.getByteArray("BlocksB2Hi"));
+        } else {
+            blocks2Hi = null;
+        }
+
+        this.blocks[y] = i -> {
+            int nibbleShift = (i & 1) * 4;
+            short id = (short) (blocks1Byte.get(i) & 0xFF);
+            if (blocks2Lo != null) {
+                id |= (short) (((blocks2Lo.get(i >> 1) >> nibbleShift) & 0xF) << 8);
+            }
+            if (blocks2Hi != null) {
+                id |= (short) (((blocks2Hi.get(i >> 1) >> nibbleShift) & 0xF) << 12);
+            }
+            return id;
+        };
+
+        // 000F
+        ByteBuffer meta1Lo = ByteBuffer.wrap(section.getByteArray("Data"));
+        // 00F0
+        ByteBuffer meta1Hi;
+        if (section.hasKey("Data1High")) {
+            meta1Hi = ByteBuffer.wrap(section.getByteArray("Data1High"));
+        } else {
+            meta1Hi = null;
+        }
+        // FF00
+        ByteBuffer meta2;
+        if (section.hasKey("Data2")) {
+            meta2 = ByteBuffer.wrap(section.getByteArray("Data2"));
+        } else {
+            meta2 = null;
+        }
+
+        this.metas[y] = i -> {
+            int nibbleShift = (i & 1) * 4;
+            short meta = 0;
+            meta |= (short) (((meta1Lo.get(i >> 1) >> nibbleShift) & 0xF));
+            if (meta1Hi != null) {
+                meta |= (short) (((meta1Hi.get(i >> 1) >> nibbleShift) & 0xF) << 4);
+            }
+            if (meta2 != null) {
+                meta |= (short) ((meta2.get(i) & 0xFF) << 8);
+            }
+            return meta;
+        };
+
     }
 
     public int getBlockId(int x, int y, int z) {

--- a/src/main/java/com/sinthoras/visualprospecting/database/cachebuilder/PartiallyLoadedChunk.java
+++ b/src/main/java/com/sinthoras/visualprospecting/database/cachebuilder/PartiallyLoadedChunk.java
@@ -267,16 +267,26 @@ public class PartiallyLoadedChunk {
             }
         }
 
-        for (int y = 0; y < PartiallyLoadedChunk.CHUNK_HEIGHT; y++) {
-            for (int z = 0; z < 16; z++) {
-                for (int x = 0; x < 16; x++) {
-                    Block block = getBlock(x, y, z);
-                    int meta = getBlockMeta(x, y, z);
+        // Iterate per-section so the blocks/metas array lookups are done out of the inner loop
+        for (int section = 0; section < SECTIONS_PER_CHUNK; section++) {
+            Int2IntFunction blocks = this.blocks[section];
+            Int2IntFunction metas = this.metas[section];
 
-                    try (OreInfo<IOreMaterial> info = OreManager.getOreInfo(block, meta)) {
-                        if (info == null || info.isSmall || !info.isNatural || info.material == null) continue;
+            int baseY = section << 4;
+            for (int dy = 0; dy < SECTION_SIZE; dy++) {
+                int y = baseY + dy;
+                for (int z = 0; z < SECTION_SIZE; z++) {
+                    for (int x = 0; x < SECTION_SIZE; x++) {
+                        int withinSection = (dy << 8) | (z << 4) | x;
+                        int id = blocks == null ? 0 : blocks.get(withinSection);
+                        int meta = metas == null ? 0 : metas.get(withinSection);
+                        Block block = Block.getBlockById(id);
 
-                        consumer.visit(x, y, z, info);
+                        try (OreInfo<IOreMaterial> info = OreManager.getOreInfo(block, meta)) {
+                            if (info == null || info.isSmall || !info.isNatural || info.material == null) continue;
+
+                            consumer.visit(x, y, z, info);
+                        }
                     }
                 }
             }

--- a/src/main/java/com/sinthoras/visualprospecting/database/cachebuilder/PartiallyLoadedChunk.java
+++ b/src/main/java/com/sinthoras/visualprospecting/database/cachebuilder/PartiallyLoadedChunk.java
@@ -44,42 +44,8 @@ public class PartiallyLoadedChunk {
             byte y = section.getByte("Y");
 
             if (section.hasKey("Blocks16")) {
-                // chunk saved with NotEnoughIds
-
-                ShortBuffer blocks = ByteBuffer.wrap(section.getByteArray("Blocks16")).asShortBuffer();
-                ShortBuffer metas = ByteBuffer.wrap(section.getByteArray("Data16")).asShortBuffer();
-
-                if (blocks.capacity() == 0 || metas.capacity() == 0) {
-                    // no-op for empty sections
-                    this.blocks[y] = i -> (short) 0;
-                    this.metas[y] = i -> (short) 0;
-                    continue;
-                }
-
-                if (blocks.capacity() != BLOCKS_PER_EBS) {
-                    VP.LOG.error(
-                            "Corrupt section detected at X={}, Y={}, Z={} (Blocks16 length was {}, needs {})",
-                            chunkX,
-                            y,
-                            chunkZ,
-                            blocks.capacity(),
-                            BLOCKS_PER_EBS);
-                    continue;
-                }
-
-                if (metas.capacity() != BLOCKS_PER_EBS) {
-                    VP.LOG.error(
-                            "Corrupt section detected at X={}, Y={}, Z={} (Data16 length was {}, needs {})",
-                            chunkX,
-                            y,
-                            chunkZ,
-                            metas.capacity(),
-                            BLOCKS_PER_EBS);
-                    continue;
-                }
-
-                this.blocks[y] = blocks::get;
-                this.metas[y] = metas::get;
+                // NotEnoughIDs format: full 16-bit block IDs and metas stored as ShortBuffers.
+                loadNotEnoughIds(section, chunkX, y, chunkZ);
 
             } else if (section.hasKey("Add") || section.hasKey("BlocksB2Hi")) {
                 // chunk saved with EndlessIds
@@ -152,6 +118,47 @@ public class PartiallyLoadedChunk {
         }
 
         tiles = chunk.getCompoundTag("Level").getTagList("TileEntities", NBT.TAG_COMPOUND).tagList;
+    }
+
+    /**
+     * Loads a chunk section saved in NotEnoughIDs format ("Blocks16" / "Data16"). Block IDs and metas are stored as
+     * flat ShortBuffers - one short per block, no bit packing.
+     */
+    private void loadNotEnoughIds(NBTTagCompound section, int chunkX, byte y, int chunkZ) {
+        ShortBuffer blocks = ByteBuffer.wrap(section.getByteArray("Blocks16")).asShortBuffer();
+        ShortBuffer metas = ByteBuffer.wrap(section.getByteArray("Data16")).asShortBuffer();
+
+        if (blocks.capacity() == 0 || metas.capacity() == 0) {
+            // no-op for empty sections
+            this.blocks[y] = i -> (short) 0;
+            this.metas[y] = i -> (short) 0;
+            return;
+        }
+
+        if (blocks.capacity() != BLOCKS_PER_EBS) {
+            VP.LOG.error(
+                    "Corrupt section detected at X={}, Y={}, Z={} (Blocks16 length was {}, needs {})",
+                    chunkX,
+                    y,
+                    chunkZ,
+                    blocks.capacity(),
+                    BLOCKS_PER_EBS);
+            return;
+        }
+
+        if (metas.capacity() != BLOCKS_PER_EBS) {
+            VP.LOG.error(
+                    "Corrupt section detected at X={}, Y={}, Z={} (Data16 length was {}, needs {})",
+                    chunkX,
+                    y,
+                    chunkZ,
+                    metas.capacity(),
+                    BLOCKS_PER_EBS);
+            return;
+        }
+
+        this.blocks[y] = blocks::get;
+        this.metas[y] = metas::get;
     }
 
     public int getBlockId(int x, int y, int z) {

--- a/src/main/java/com/sinthoras/visualprospecting/database/cachebuilder/PartiallyLoadedChunk.java
+++ b/src/main/java/com/sinthoras/visualprospecting/database/cachebuilder/PartiallyLoadedChunk.java
@@ -62,8 +62,7 @@ public class PartiallyLoadedChunk {
                 // bits 0x00F0 — "Data1High" nibble array (EndlessIDs extension)
                 // bits 0xFF00 — "Data2" byte array (EndlessIDs extension, 1 byte per block)
                 //
-                // "Add", "BlocksB2Hi", "BlocksB3", "Data1High", and "Data2" are all optional —
-                // absent arrays mean those bits are zero, preserving backwards compatibility.
+                // "Add", "BlocksB2Hi", "BlocksB3", "Data1High", and "Data2" are all optional
                 // Reference:
                 // https://github.com/GTMEGA/EndlessIDs/blob/master/src/main/java/com/falsepattern/endlessids/managers/BlockIDManager.java
                 // https://github.com/GTMEGA/EndlessIDs/blob/master/src/main/java/com/falsepattern/endlessids/managers/BlockMetaManager.java
@@ -126,9 +125,9 @@ public class PartiallyLoadedChunk {
      * optional and treated as all-zero when absent. A corrupt mandatory array zeroes the whole section.
      */
     private void loadEndlessIds(NBTTagCompound section, int chunkX, byte y, int chunkZ) {
-        ByteBuffer blockLo = loadOptionalArray(section, "Blocks", BLOCKS_PER_EBS, chunkX, y, chunkZ);
-        ByteBuffer metaLo = loadOptionalArray(section, "Data", NIBBLE_ARRAY_SIZE, chunkX, y, chunkZ);
-        if (blockLo == null || metaLo == null) {
+        ByteBuffer blockB1 = loadOptionalArray(section, "Blocks", BLOCKS_PER_EBS, chunkX, y, chunkZ);
+        ByteBuffer metaM1Lo = loadOptionalArray(section, "Data", NIBBLE_ARRAY_SIZE, chunkX, y, chunkZ);
+        if (blockB1 == null || metaM1Lo == null) {
             VP.LOG.error(
                     "Corrupt EndlessIDs section at X={}, Y={}, Z={}: missing or invalid mandatory Blocks/Data array",
                     chunkX,
@@ -139,27 +138,27 @@ public class PartiallyLoadedChunk {
             return;
         }
 
-        ByteBuffer blockMid = loadOptionalArray(section, "Add", NIBBLE_ARRAY_SIZE, chunkX, y, chunkZ);
-        ByteBuffer blockHi = loadOptionalArray(section, "BlocksB2Hi", NIBBLE_ARRAY_SIZE, chunkX, y, chunkZ);
+        ByteBuffer blockB2Lo = loadOptionalArray(section, "Add", NIBBLE_ARRAY_SIZE, chunkX, y, chunkZ);
+        ByteBuffer blockB2Hi = loadOptionalArray(section, "BlocksB2Hi", NIBBLE_ARRAY_SIZE, chunkX, y, chunkZ);
         ByteBuffer blockB3 = loadOptionalArray(section, "BlocksB3", BLOCKS_PER_EBS, chunkX, y, chunkZ);
 
         this.blocks[y] = i -> {
             int nibbleShift = (i & 1) * 4;
-            int id = blockLo.get(i) & 0xFF;
-            if (blockMid != null) id |= ((blockMid.get(i >> 1) >> nibbleShift) & 0xF) << 8;
-            if (blockHi != null) id |= ((blockHi.get(i >> 1) >> nibbleShift) & 0xF) << 12;
+            int id = blockB1.get(i) & 0xFF;
+            if (blockB2Lo != null) id |= ((blockB2Lo.get(i >> 1) >> nibbleShift) & 0xF) << 8;
+            if (blockB2Hi != null) id |= ((blockB2Hi.get(i >> 1) >> nibbleShift) & 0xF) << 12;
             if (blockB3 != null) id |= (blockB3.get(i) & 0xFF) << 16;
             return id;
         };
 
-        ByteBuffer metaMid = loadOptionalArray(section, "Data1High", NIBBLE_ARRAY_SIZE, chunkX, y, chunkZ);
-        ByteBuffer metaHi = loadOptionalArray(section, "Data2", BLOCKS_PER_EBS, chunkX, y, chunkZ);
+        ByteBuffer metaM1Hi = loadOptionalArray(section, "Data1High", NIBBLE_ARRAY_SIZE, chunkX, y, chunkZ);
+        ByteBuffer metaM2 = loadOptionalArray(section, "Data2", BLOCKS_PER_EBS, chunkX, y, chunkZ);
 
         this.metas[y] = i -> {
             int nibbleShift = (i & 1) * 4;
-            int meta = (metaLo.get(i >> 1) >> nibbleShift) & 0xF;
-            if (metaMid != null) meta |= ((metaMid.get(i >> 1) >> nibbleShift) & 0xF) << 4;
-            if (metaHi != null) meta |= (metaHi.get(i) & 0xFF) << 8;
+            int meta = (metaM1Lo.get(i >> 1) >> nibbleShift) & 0xF;
+            if (metaM1Hi != null) meta |= ((metaM1Hi.get(i >> 1) >> nibbleShift) & 0xF) << 4;
+            if (metaM2 != null) meta |= (metaM2.get(i) & 0xFF) << 8;
             return meta;
         };
     }

--- a/src/main/java/com/sinthoras/visualprospecting/database/cachebuilder/PartiallyLoadedChunk.java
+++ b/src/main/java/com/sinthoras/visualprospecting/database/cachebuilder/PartiallyLoadedChunk.java
@@ -186,46 +186,6 @@ public class PartiallyLoadedChunk {
         return ByteBuffer.wrap(data);
     }
 
-    public int getBlockId(int x, int y, int z) {
-        if (x < 0 || x >= 16) throw new IllegalArgumentException("x");
-        if (y < 0 || y >= CHUNK_HEIGHT) throw new IllegalArgumentException("y");
-        if (z < 0 || z >= 16) throw new IllegalArgumentException("z");
-
-        int index = y << 8 | z << 4 | x;
-
-        int section = index / BLOCKS_PER_EBS;
-
-        Int2IntFunction blocks = this.blocks[section];
-
-        if (blocks == null) return 0;
-
-        int withinSection = index % BLOCKS_PER_EBS;
-
-        return blocks.get(withinSection);
-    }
-
-    public Block getBlock(int x, int y, int z) {
-        return Block.getBlockById(getBlockId(x, y, z));
-    }
-
-    public int getBlockMeta(int x, int y, int z) {
-        if (x < 0 || x >= 16) throw new IllegalArgumentException("x");
-        if (y < 0 || y >= CHUNK_HEIGHT) throw new IllegalArgumentException("y");
-        if (z < 0 || z >= 16) throw new IllegalArgumentException("z");
-
-        int index = y << 8 | z << 4 | x;
-
-        int section = index / BLOCKS_PER_EBS;
-
-        Int2IntFunction metas = this.metas[section];
-
-        if (metas == null) return 0;
-
-        int withinSection = index % BLOCKS_PER_EBS;
-
-        return metas.get(withinSection);
-    }
-
     public interface OreConsumer {
 
         void visit(int x, int y, int z, OreInfo<IOreMaterial> ore);

--- a/src/main/java/com/sinthoras/visualprospecting/database/cachebuilder/WorldAnalysis.java
+++ b/src/main/java/com/sinthoras/visualprospecting/database/cachebuilder/WorldAnalysis.java
@@ -28,7 +28,8 @@ import it.unimi.dsi.fastutil.ints.IntSets;
 
 public class WorldAnalysis {
 
-    private static final EnumSet<VeinSource> RESCAN_PROTECTED = EnumSet.of(VeinSource.GENERATED, VeinSource.API);
+    private static final EnumSet<VeinSource> RESCAN_PROTECTED = EnumSet
+            .of(VeinSource.GENERATED, VeinSource.API, VeinSource.UNKNOWN);
 
     private final File worldFolder;
 
@@ -38,7 +39,7 @@ public class WorldAnalysis {
 
     public void cacheOverworldSpawnVeins(ChunkCoordinates spawn) throws IOException, DataFormatException {
 
-        VP.info("Starting to parse world save to cache GT vein locations near spawn. This might take some time...");
+        VP.LOG.info("Starting to parse world save to cache GT vein locations near spawn. This might take some time...");
         ServerCache.instance.resetSpawnChunks(spawn, 0, RESCAN_PROTECTED);
 
         cacheVeins(IntSets.singleton(0));
@@ -46,7 +47,7 @@ public class WorldAnalysis {
 
     public void cacheVeins() throws IOException, DataFormatException {
 
-        VP.info("Starting to parse world save to cache GT vein locations. This might take some time...");
+        VP.LOG.info("Starting to parse world save to cache GT vein locations. This might take some time...");
         ServerCache.instance.resetExcept(RESCAN_PROTECTED);
 
         cacheVeins(getDimensionIds());
@@ -74,7 +75,7 @@ public class WorldAnalysis {
         }
 
         AnalysisProgressTracker.processingFinished();
-        VP.info("Saving ore vein cache...");
+        VP.LOG.info("Saving ore vein cache...");
         ServerCache.instance.saveVeinCache();
     }
 

--- a/src/main/java/com/sinthoras/visualprospecting/database/cachebuilder/WorldAnalysis.java
+++ b/src/main/java/com/sinthoras/visualprospecting/database/cachebuilder/WorldAnalysis.java
@@ -81,7 +81,7 @@ public class WorldAnalysis {
     public IntSet getDimensionIds() throws IOException {
         IntSet dimensionIds = new IntOpenHashSet();
         dimensionIds.addAll(Arrays.asList(DimensionManager.getIDs()));
-        try (Stream<Path> files = Files.walk(worldFolder.toPath(), 1)) {
+        try (Stream<Path> files = Files.list(worldFolder.toPath())) {
             files.filter(Files::isDirectory).map(path -> path.getFileName().toString())
                     .filter(path -> path.startsWith("DIM")).map(path -> path.substring(3)).forEach(dim -> {
                         try {
@@ -98,8 +98,8 @@ public class WorldAnalysis {
         if (world != null) {
             dimRegionDir = new File(world.getChunkSaveLocation(), "region");
         } else {
-            final String subfolder = dimensionId == 0 ? "" : "/DIM" + dimensionId;
-            dimRegionDir = new File(worldFolder, subfolder + "/region");
+            final File dimFolder = dimensionId == 0 ? worldFolder : new File(worldFolder, "DIM" + dimensionId);
+            dimRegionDir = new File(dimFolder, "region");
         }
 
         if (dimRegionDir.exists()) {

--- a/src/main/java/com/sinthoras/visualprospecting/database/cachebuilder/WorldAnalysis.java
+++ b/src/main/java/com/sinthoras/visualprospecting/database/cachebuilder/WorldAnalysis.java
@@ -7,6 +7,7 @@ import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.EnumSet;
 import java.util.stream.Stream;
 import java.util.zip.DataFormatException;
 
@@ -18,12 +19,15 @@ import org.apache.commons.io.FileUtils;
 
 import com.sinthoras.visualprospecting.VP;
 import com.sinthoras.visualprospecting.database.ServerCache;
+import com.sinthoras.visualprospecting.database.VeinSource;
 
 import it.unimi.dsi.fastutil.ints.IntOpenHashSet;
 import it.unimi.dsi.fastutil.ints.IntSet;
 import it.unimi.dsi.fastutil.ints.IntSets;
 
 public class WorldAnalysis {
+
+    private static final EnumSet<VeinSource> RESCAN_PROTECTED = EnumSet.of(VeinSource.GENERATED, VeinSource.API);
 
     private final File worldFolder;
 
@@ -34,7 +38,7 @@ public class WorldAnalysis {
     public void cacheOverworldSpawnVeins(ChunkCoordinates spawn) throws IOException, DataFormatException {
 
         VP.info("Starting to parse world save to cache GT vein locations near spawn. This might take some time...");
-        ServerCache.instance.resetSpawnChunks(spawn, 0);
+        ServerCache.instance.resetSpawnChunks(spawn, 0, RESCAN_PROTECTED);
 
         cacheVeins(IntSets.singleton(0));
     }
@@ -42,7 +46,7 @@ public class WorldAnalysis {
     public void cacheVeins() throws IOException, DataFormatException {
 
         VP.info("Starting to parse world save to cache GT vein locations. This might take some time...");
-        ServerCache.instance.reset();
+        ServerCache.instance.resetExcept(RESCAN_PROTECTED);
 
         cacheVeins(getDimensionIds());
     }

--- a/src/main/java/com/sinthoras/visualprospecting/database/cachebuilder/WorldAnalysis.java
+++ b/src/main/java/com/sinthoras/visualprospecting/database/cachebuilder/WorldAnalysis.java
@@ -20,6 +20,7 @@ import org.apache.commons.io.FileUtils;
 import com.sinthoras.visualprospecting.VP;
 import com.sinthoras.visualprospecting.database.ServerCache;
 import com.sinthoras.visualprospecting.database.VeinSource;
+import com.sinthoras.visualprospecting.database.veintypes.VeinTypeCaching;
 
 import it.unimi.dsi.fastutil.ints.IntOpenHashSet;
 import it.unimi.dsi.fastutil.ints.IntSet;
@@ -55,8 +56,19 @@ public class WorldAnalysis {
 
         AnalysisProgressTracker.setNumberOfDimensions(dimensionIds.size());
         for (int dimensionId : dimensionIds) {
-            final Collection<File> regionFiles = getRegionFilesForDim(dimensionId);
             final DimensionAnalysis dimension = new DimensionAnalysis(dimensionId);
+
+            // Skip dimensions in with no known GT OreMixes
+            if (!VeinTypeCaching.hasVeinsInDimension(dimension.dimensionName)) {
+                VP.LOG.info(
+                        "Skipping dimensionId={} name=\"{}\" - no ore veins generate in this dimension.",
+                        dimensionId,
+                        dimension.dimensionName);
+                AnalysisProgressTracker.dimensionProcessed();
+                continue;
+            }
+
+            final Collection<File> regionFiles = getRegionFilesForDim(dimensionId);
             dimension.processMinecraftWorld(regionFiles);
             AnalysisProgressTracker.dimensionProcessed();
         }

--- a/src/main/java/com/sinthoras/visualprospecting/database/veintypes/VeinType.java
+++ b/src/main/java/com/sinthoras/visualprospecting/database/veintypes/VeinType.java
@@ -11,6 +11,7 @@ import javax.annotation.ParametersAreNonnullByDefault;
 import com.google.common.collect.ImmutableList;
 import com.sinthoras.visualprospecting.Tags;
 
+import galacticgreg.api.enums.DimensionDef.DimNames;
 import gregtech.api.interfaces.IOreMaterial;
 import gregtech.common.OreMixBuilder;
 
@@ -61,6 +62,14 @@ public class VeinType {
         minBlockY = Math.max(0, oreMix.minY - 6);
         maxBlockY = Math.min(255, oreMix.maxY - 6);
         allowedDims.addAll(oreMix.dimsEnabled);
+
+        // Fuse entries for "The End" and "EndAsteroid" since they are both about same dimension.
+        // World gen swap which one is used around 16 chunks from central point.
+        final boolean inEnd = allowedDims.contains(DimNames.THE_END);
+        final boolean inEndAsteroid = allowedDims.contains(DimNames.ENDASTEROID);
+        if (inEnd != inEndAsteroid) {
+            allowedDims.add(inEnd ? DimNames.ENDASTEROID : DimNames.THE_END);
+        }
     }
 
     public boolean containsAllFoundOres(Collection<IOreMaterial> foundOres, String dimName, IOreMaterial specific,

--- a/src/main/java/com/sinthoras/visualprospecting/database/veintypes/VeinType.java
+++ b/src/main/java/com/sinthoras/visualprospecting/database/veintypes/VeinType.java
@@ -2,7 +2,7 @@ package com.sinthoras.visualprospecting.database.veintypes;
 
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.HashSet;
+import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -14,10 +14,12 @@ import com.sinthoras.visualprospecting.Tags;
 import galacticgreg.api.enums.DimensionDef.DimNames;
 import gregtech.api.interfaces.IOreMaterial;
 import gregtech.common.OreMixBuilder;
+import it.unimi.dsi.fastutil.objects.ReferenceOpenHashSet;
 
 @ParametersAreNonnullByDefault
 public class VeinType {
 
+    // A vein spans 9 block layers in GT WorldgenGTOreLayer.
     public static final int veinHeight = 9;
 
     public final String name;
@@ -29,7 +31,9 @@ public class VeinType {
     public final IOreMaterial sporadicOre;
     public final int minBlockY;
     public final int maxBlockY;
-    private final HashSet<IOreMaterial> oresAsSet = new HashSet<IOreMaterial>();
+    private final ReferenceOpenHashSet<IOreMaterial> oresAsSet = new ReferenceOpenHashSet<>();
+    private final ReferenceOpenHashSet<IOreMaterial> nonSporadicOres = new ReferenceOpenHashSet<>();
+    private final List<List<IOreMaterial>> oresByLayer;
     private final List<String> allowedDims = new ArrayList<>();
     private boolean isHighlighted = true;
     private final String localizedName;
@@ -48,6 +52,7 @@ public class VeinType {
         this.inBetweenOre = null;
         this.sporadicOre = null;
         this.localizedName = this.name;
+        this.oresByLayer = buildOresByLayer();
     }
 
     public VeinType(OreMixBuilder oreMix) {
@@ -59,6 +64,10 @@ public class VeinType {
         oresAsSet.add(secondaryOre = oreMix.secondary);
         oresAsSet.add(inBetweenOre = oreMix.between);
         oresAsSet.add(sporadicOre = oreMix.sporadic);
+        nonSporadicOres.add(primaryOre);
+        nonSporadicOres.add(secondaryOre);
+        nonSporadicOres.add(inBetweenOre);
+        oresByLayer = buildOresByLayer();
         minBlockY = Math.max(0, oreMix.minY - 6);
         maxBlockY = Math.min(255, oreMix.maxY - 6);
         allowedDims.addAll(oreMix.dimsEnabled);
@@ -84,6 +93,12 @@ public class VeinType {
         return (primaryOre == specific || secondaryOre == specific)
                 && (dimName.isEmpty() || allowedDims.contains(dimName))
                 && foundOres.containsAll(oresAsSet);
+    }
+
+    public boolean matchesIgnoringSporadic(Collection<IOreMaterial> foundOres, String dimName, IOreMaterial specific) {
+        return (primaryOre == specific || secondaryOre == specific)
+                && (dimName.isEmpty() || allowedDims.contains(dimName))
+                && foundOres.containsAll(nonSporadicOres);
     }
 
     public List<String> getAllowedDimensions() {
@@ -113,40 +128,44 @@ public class VeinType {
     }
 
     public List<IOreMaterial> getOresAtLayer(int layerBlockY) {
-        final List<IOreMaterial> result = new ArrayList<>();
-
-        switch (layerBlockY) {
-            case 0, 1, 2 -> {
-                result.add(secondaryOre);
-                result.add(sporadicOre);
-                return result;
-            }
-            case 3 -> {
-                result.add(secondaryOre);
-                result.add(inBetweenOre);
-                result.add(sporadicOre);
-                return result;
-            }
-            case 4 -> {
-                result.add(inBetweenOre);
-                result.add(sporadicOre);
-                return result;
-            }
-            case 5, 6 -> {
-                result.add(primaryOre);
-                result.add(inBetweenOre);
-                result.add(sporadicOre);
-                return result;
-            }
-            case 7, 8 -> {
-                result.add(primaryOre);
-                result.add(sporadicOre);
-                return result;
-            }
-            default -> {
-                return result;
-            }
+        if (layerBlockY < 0 || layerBlockY >= veinHeight) {
+            return Collections.emptyList();
         }
+        return oresByLayer.get(layerBlockY);
+    }
+
+    // Layer -> ores mirrors GT WorldgenGTOreLayer placement
+    private List<List<IOreMaterial>> buildOresByLayer() {
+        final List<List<IOreMaterial>> layers = new ArrayList<>(veinHeight);
+        for (int layer = 0; layer < veinHeight; layer++) {
+            final List<IOreMaterial> ores = new ArrayList<>(3);
+            switch (layer) {
+                case 0, 1, 2 -> {
+                    ores.add(secondaryOre);
+                    ores.add(sporadicOre);
+                }
+                case 3 -> {
+                    ores.add(secondaryOre);
+                    ores.add(inBetweenOre);
+                    ores.add(sporadicOre);
+                }
+                case 4 -> {
+                    ores.add(inBetweenOre);
+                    ores.add(sporadicOre);
+                }
+                case 5, 6 -> {
+                    ores.add(primaryOre);
+                    ores.add(inBetweenOre);
+                    ores.add(sporadicOre);
+                }
+                case 7, 8 -> {
+                    ores.add(primaryOre);
+                    ores.add(sporadicOre);
+                }
+            }
+            layers.add(ores);
+        }
+        return layers;
     }
 
     public boolean isHighlighted() {

--- a/src/main/java/com/sinthoras/visualprospecting/database/veintypes/VeinType.java
+++ b/src/main/java/com/sinthoras/visualprospecting/database/veintypes/VeinType.java
@@ -77,6 +77,10 @@ public class VeinType {
                 && foundOres.containsAll(oresAsSet);
     }
 
+    public List<String> getAllowedDimensions() {
+        return allowedDims;
+    }
+
     public boolean canOverlapIntoNeighborOreChunk() {
         return blockSize > 24;
     }

--- a/src/main/java/com/sinthoras/visualprospecting/database/veintypes/VeinTypeCaching.java
+++ b/src/main/java/com/sinthoras/visualprospecting/database/veintypes/VeinTypeCaching.java
@@ -2,6 +2,7 @@ package com.sinthoras.visualprospecting.database.veintypes;
 
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
 import java.util.regex.Pattern;
 
@@ -13,10 +14,13 @@ import org.jetbrains.annotations.Nullable;
 import com.sinthoras.visualprospecting.Tags;
 
 import gregtech.api.enums.OreMixes;
+import gregtech.api.interfaces.IOreMaterial;
 import it.unimi.dsi.fastutil.objects.Object2ObjectMap;
 import it.unimi.dsi.fastutil.objects.Object2ObjectOpenHashMap;
 import it.unimi.dsi.fastutil.objects.ObjectOpenHashSet;
 import it.unimi.dsi.fastutil.objects.ObjectSet;
+import it.unimi.dsi.fastutil.objects.Reference2ObjectMap;
+import it.unimi.dsi.fastutil.objects.Reference2ObjectOpenHashMap;
 
 public class VeinTypeCaching {
 
@@ -24,6 +28,9 @@ public class VeinTypeCaching {
 
     // Dimensions without registered OreMixes are not expected to match anything
     private static final ObjectSet<String> dimensionsWithVeins = new ObjectOpenHashSet<>();
+
+    // VeinTypes indexed by primary/secondary Ore in OreMix. For faster matching
+    private static final Reference2ObjectMap<IOreMaterial, List<VeinType>> veinTypesByPrimaryOrSecondary = new Reference2ObjectOpenHashMap<>();
 
     public static void init() {
         veinTypes.put(Tags.ORE_MIX_NONE_NAME, VeinType.NO_VEIN);
@@ -33,10 +40,25 @@ public class VeinTypeCaching {
         }
 
         dimensionsWithVeins.clear();
+        veinTypesByPrimaryOrSecondary.clear();
         for (VeinType veinType : veinTypes.values()) {
             if (veinType == VeinType.NO_VEIN) continue;
             dimensionsWithVeins.addAll(veinType.getAllowedDimensions());
+            indexByOre(veinType.primaryOre, veinType);
+            if (veinType.secondaryOre != veinType.primaryOre) {
+                indexByOre(veinType.secondaryOre, veinType);
+            }
         }
+    }
+
+    private static void indexByOre(IOreMaterial ore, VeinType veinType) {
+        if (ore == null) return;
+        List<VeinType> matchingVeinTypes = veinTypesByPrimaryOrSecondary.get(ore);
+        if (matchingVeinTypes == null) {
+            matchingVeinTypes = new ArrayList<>();
+            veinTypesByPrimaryOrSecondary.put(ore, matchingVeinTypes);
+        }
+        matchingVeinTypes.add(veinType);
     }
 
     public static boolean hasVeinsInDimension(String dimensionName) {
@@ -49,6 +71,11 @@ public class VeinTypeCaching {
 
     public static Collection<VeinType> getVeinTypes() {
         return veinTypes.values();
+    }
+
+    public static List<VeinType> getVeinTypesForOre(IOreMaterial dominantOre) {
+        final List<VeinType> matchingVeinTypes = veinTypesByPrimaryOrSecondary.get(dominantOre);
+        return matchingVeinTypes == null ? Collections.emptyList() : matchingVeinTypes;
     }
 
     public static void recalculateSearch(@Nullable Pattern filterPattern) {

--- a/src/main/java/com/sinthoras/visualprospecting/database/veintypes/VeinTypeCaching.java
+++ b/src/main/java/com/sinthoras/visualprospecting/database/veintypes/VeinTypeCaching.java
@@ -1,7 +1,5 @@
 package com.sinthoras.visualprospecting.database.veintypes;
 
-import static com.sinthoras.visualprospecting.Utils.*;
-
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
@@ -17,10 +15,15 @@ import com.sinthoras.visualprospecting.Tags;
 import gregtech.api.enums.OreMixes;
 import it.unimi.dsi.fastutil.objects.Object2ObjectMap;
 import it.unimi.dsi.fastutil.objects.Object2ObjectOpenHashMap;
+import it.unimi.dsi.fastutil.objects.ObjectOpenHashSet;
+import it.unimi.dsi.fastutil.objects.ObjectSet;
 
 public class VeinTypeCaching {
 
     private static final Object2ObjectMap<String, VeinType> veinTypes = new Object2ObjectOpenHashMap<>();
+
+    // Dimensions without registered OreMixes are not expected to match anything
+    private static final ObjectSet<String> dimensionsWithVeins = new ObjectOpenHashSet<>();
 
     public static void init() {
         veinTypes.put(Tags.ORE_MIX_NONE_NAME, VeinType.NO_VEIN);
@@ -28,6 +31,16 @@ public class VeinTypeCaching {
         for (OreMixes mix : OreMixes.values()) {
             veinTypes.put(mix.oreMixBuilder.oreMixName, new VeinType(mix.oreMixBuilder));
         }
+
+        dimensionsWithVeins.clear();
+        for (VeinType veinType : veinTypes.values()) {
+            if (veinType == VeinType.NO_VEIN) continue;
+            dimensionsWithVeins.addAll(veinType.getAllowedDimensions());
+        }
+    }
+
+    public static boolean hasVeinsInDimension(String dimensionName) {
+        return dimensionsWithVeins.contains(dimensionName);
     }
 
     public static @NotNull VeinType getVeinType(String veinTypeName) {

--- a/src/main/java/com/sinthoras/visualprospecting/database/veintypes/VeinTypeCaching.java
+++ b/src/main/java/com/sinthoras/visualprospecting/database/veintypes/VeinTypeCaching.java
@@ -33,6 +33,7 @@ public class VeinTypeCaching {
     private static final Reference2ObjectMap<IOreMaterial, List<VeinType>> veinTypesByPrimaryOrSecondary = new Reference2ObjectOpenHashMap<>();
 
     public static void init() {
+        veinTypes.clear();
         veinTypes.put(Tags.ORE_MIX_NONE_NAME, VeinType.NO_VEIN);
 
         for (OreMixes mix : OreMixes.values()) {


### PR DESCRIPTION
This ended up being a lot more changes than the few little tweaks I originally wanted to go for.

Looking at my commits in order:
- Improved EndlessIDs support: Support all keys, check for corruptions same way as it did for NEIds
- Bunch of various optimisations
- Fixed a bug in vein matching that made it not always retry when it should be
- Add trust hierarchy on ore vein storage with an overwrite logic depending on VeinSource. Now that we can flag what came from a GT VeinGenerateEvent we consider it more trustable than rescan.
- Fixed how VP get dimension names because it often got empty strings which made matching try all OreMixes instead of filtering
- This also allow us to skip scanning dimensions that don't have any mix registered.
- After talking about it in discord, move VeinSource away from using ordinals to avoid future troubles
- Changed scan logic: No more fast or slow dimension depending on file size. It scan region files by rows and discard data from memory once it's not needed any more.
- In case rescan doesn't find anything it default to not overwriting an unknown sourced vein. Avoid making holes where there is a depleted vein or where it still failed to match.

From what I've seen it's never slower than before, It's even usually a bit faster.

### Comparison
| Original Cache                                                                                                                                        | Current VP recache output                                                                                                                                      | New recache output                                                                                                                                                | (Bonus) New output with deleted cache                                                                                                                                        |
|-------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
| <img width="2560" height="1369" alt="2026-06-06_09 52 38 OG" src="https://github.com/user-attachments/assets/13793008-3753-46ac-8c30-83e838d32164" /> | <img width="2560" height="1369" alt="2026-06-06_10 08 40 Old recache" src="https://github.com/user-attachments/assets/8b20de5d-e23b-494c-97ad-ebe0becf4716" /> | <img width="2560" height="1369" alt="2026-06-06_11 31 14 new recache v2" src="https://github.com/user-attachments/assets/13a10ad5-b60a-4a9c-9f78-2422c662ea20" /> | <img width="2560" height="1369" alt="2026-06-06_18 28 21 new recache v2 from empty" src="https://github.com/user-attachments/assets/71f88a0a-985f-4f06-854a-29fdc65b5199" /> |
| <img width="2560" height="1369" alt="2026-06-06_09 53 04 OG" src="https://github.com/user-attachments/assets/b9578783-d0a2-4c0c-940a-3cd3073f4373" /> | <img width="2560" height="1369" alt="2026-06-06_10 09 23 Old recache" src="https://github.com/user-attachments/assets/ef83b1de-e31b-4644-8f5d-89bc57feec32" /> | <img width="2560" height="1369" alt="2026-06-06_11 31 31 New recache v2" src="https://github.com/user-attachments/assets/d208197a-604b-46cf-8ebf-8704e81a210f" /> | <img width="2560" height="1369" alt="2026-06-06_18 28 49 new recache v2 from empty" src="https://github.com/user-attachments/assets/8c005f88-5238-4e37-b323-8c35a13f1d95" /> |

4th column is to accurately compare what scan find without preserving any entries.
You'll see it's overall a bit better or identical but never worse.

