### PR TITLE
Show more clear indicator on overlay for what fluid amount mean

### DIFF
--- a/src/main/java/com/sinthoras/visualprospecting/integration/model/render/UndergroundFluidRenderStep.java
+++ b/src/main/java/com/sinthoras/visualprospecting/integration/model/render/UndergroundFluidRenderStep.java
@@ -116,10 +116,7 @@ public class UndergroundFluidRenderStep extends UniversalRenderStep<UndergroundF
     }
 
     private String getFluidAmountFormatted(int amount) {
-        return getLitresFormatted((long) amount * UndergroundOil.DIVIDER);
-    }
-
-    private String getLitresFormatted(long litres) {
+        final long litres = (long) amount * UndergroundOil.DIVIDER;
         if (litres >= 1_000_000_000) {
             return getRoundedAmountFormatted(litres, 1_000_000_000, "GL");
         }

--- a/src/main/java/com/sinthoras/visualprospecting/integration/model/render/UndergroundFluidRenderStep.java
+++ b/src/main/java/com/sinthoras/visualprospecting/integration/model/render/UndergroundFluidRenderStep.java
@@ -130,12 +130,12 @@ public class UndergroundFluidRenderStep extends UniversalRenderStep<UndergroundF
     }
 
     private String getRoundedAmountFormatted(long litres, long scale, String unit) {
-        final long tenths = (litres * 10 + scale / 2) / scale;
-        final long whole = tenths / 10;
-        final long decimal = tenths % 10;
-        if (decimal == 0) {
-            return whole + " " + unit;
+        final long roundedTenths = (litres * 10 + scale / 2) / scale;
+        final long integerPart = roundedTenths / 10;
+        final long decimalDigit = roundedTenths % 10;
+        if (decimalDigit == 0) {
+            return integerPart + " " + unit;
         }
-        return whole + "." + decimal + " " + unit;
+        return integerPart + "." + decimalDigit + " " + unit;
     }
 }

--- a/src/main/java/com/sinthoras/visualprospecting/integration/model/render/UndergroundFluidRenderStep.java
+++ b/src/main/java/com/sinthoras/visualprospecting/integration/model/render/UndergroundFluidRenderStep.java
@@ -10,6 +10,8 @@ import com.sinthoras.visualprospecting.VP;
 import com.sinthoras.visualprospecting.integration.model.layers.UndergroundFluidLayerManager;
 import com.sinthoras.visualprospecting.integration.model.locations.UndergroundFluidLocation;
 
+import gregtech.common.UndergroundOil;
+
 public class UndergroundFluidRenderStep extends UniversalRenderStep<UndergroundFluidLocation> {
 
     public UndergroundFluidRenderStep(UndergroundFluidLocation location) {
@@ -41,9 +43,9 @@ public class UndergroundFluidRenderStep extends UniversalRenderStep<UndergroundF
         if (!isMinimap()) {
             String label = I18n.format("visualprospecting.empty");
             if (maxAmountInField > 0) {
-                label = location.getMinProduction() + "L - "
-                        + maxAmountInField
-                        + "L  "
+                label = getFluidAmountFormatted(location.getMinProduction()) + " - "
+                        + getFluidAmountFormatted(maxAmountInField)
+                        + "  "
                         + location.getFluid().getLocalizedName();
             }
 
@@ -114,9 +116,26 @@ public class UndergroundFluidRenderStep extends UniversalRenderStep<UndergroundF
     }
 
     private String getFluidAmountFormatted(int amount) {
-        if (amount >= 1000) {
-            return (amount / 1000) + "kL";
+        return getLitresFormatted((long) amount * UndergroundOil.DIVIDER);
+    }
+
+    private String getLitresFormatted(long litres) {
+        if (litres >= 1_000_000) {
+            return getRoundedAmountFormatted(litres, 1_000_000, "ML");
         }
-        return amount + "L";
+        if (litres >= 1_000) {
+            return getRoundedAmountFormatted(litres, 1_000, "kL");
+        }
+        return litres + " L";
+    }
+
+    private String getRoundedAmountFormatted(long litres, long scale, String unit) {
+        final long tenths = (litres * 10 + scale / 2) / scale;
+        final long whole = tenths / 10;
+        final long decimal = tenths % 10;
+        if (decimal == 0) {
+            return whole + " " + unit;
+        }
+        return whole + "." + decimal + " " + unit;
     }
 }

--- a/src/main/java/com/sinthoras/visualprospecting/integration/model/render/UndergroundFluidRenderStep.java
+++ b/src/main/java/com/sinthoras/visualprospecting/integration/model/render/UndergroundFluidRenderStep.java
@@ -120,6 +120,9 @@ public class UndergroundFluidRenderStep extends UniversalRenderStep<UndergroundF
     }
 
     private String getLitresFormatted(long litres) {
+        if (litres >= 1_000_000_000) {
+            return getRoundedAmountFormatted(litres, 1_000_000_000, "GL");
+        }
         if (litres >= 1_000_000) {
             return getRoundedAmountFormatted(litres, 1_000_000, "ML");
         }

--- a/src/main/java/com/sinthoras/visualprospecting/integration/model/render/UndergroundFluidRenderStep.java
+++ b/src/main/java/com/sinthoras/visualprospecting/integration/model/render/UndergroundFluidRenderStep.java
@@ -1,5 +1,7 @@
 package com.sinthoras.visualprospecting.integration.model.render;
 
+import java.text.MessageFormat;
+
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.resources.I18n;
 
@@ -41,10 +43,11 @@ public class UndergroundFluidRenderStep extends UniversalRenderStep<UndergroundF
         if (!isMinimap()) {
             String label = I18n.format("visualprospecting.empty");
             if (maxAmountInField > 0) {
-                label = getFluidAmountFormatted(location.getMinProduction()) + " - "
-                        + getFluidAmountFormatted(maxAmountInField)
-                        + "  "
-                        + location.getFluid().getLocalizedName();
+                label = MessageFormat.format(
+                        "{0}-{1} L/Op {2}",
+                        formatAmount(location.getMinProduction()),
+                        formatAmount(maxAmountInField),
+                        location.getFluid().getLocalizedName());
             }
 
             int textColor = 0xFFFFFFFF;
@@ -101,7 +104,7 @@ public class UndergroundFluidRenderStep extends UniversalRenderStep<UndergroundF
 
                 if (drawLabels) {
                     DrawUtils.drawLabel(
-                            getFluidAmountFormatted(amount),
+                            MessageFormat.format("{0} L/Op", formatAmount(amount)),
                             cellX + cellW / 2,
                             cellY + cellH / 2,
                             0xFFFFFFFF,
@@ -113,10 +116,14 @@ public class UndergroundFluidRenderStep extends UniversalRenderStep<UndergroundF
         }
     }
 
-    private String getFluidAmountFormatted(int amount) {
-        if (amount >= 1000) {
-            return (amount / 1000) + " kL/op";
+    private String formatAmount(int amount) {
+        if (amount < 1000) {
+            return String.valueOf(amount);
         }
-        return amount + " L/op";
+        final int roundedTenths = (amount + 50) / 100;
+        if (roundedTenths % 10 == 0) {
+            return (roundedTenths / 10) + "k";
+        }
+        return (roundedTenths / 10) + "." + (roundedTenths % 10) + "k";
     }
 }

--- a/src/main/java/com/sinthoras/visualprospecting/integration/model/render/UndergroundFluidRenderStep.java
+++ b/src/main/java/com/sinthoras/visualprospecting/integration/model/render/UndergroundFluidRenderStep.java
@@ -10,8 +10,6 @@ import com.sinthoras.visualprospecting.VP;
 import com.sinthoras.visualprospecting.integration.model.layers.UndergroundFluidLayerManager;
 import com.sinthoras.visualprospecting.integration.model.locations.UndergroundFluidLocation;
 
-import gregtech.common.UndergroundOil;
-
 public class UndergroundFluidRenderStep extends UniversalRenderStep<UndergroundFluidLocation> {
 
     public UndergroundFluidRenderStep(UndergroundFluidLocation location) {
@@ -116,26 +114,9 @@ public class UndergroundFluidRenderStep extends UniversalRenderStep<UndergroundF
     }
 
     private String getFluidAmountFormatted(int amount) {
-        final long litres = (long) amount * UndergroundOil.DIVIDER;
-        if (litres >= 1_000_000_000) {
-            return getRoundedAmountFormatted(litres, 1_000_000_000, "GL");
+        if (amount >= 1000) {
+            return (amount / 1000) + " kL/op";
         }
-        if (litres >= 1_000_000) {
-            return getRoundedAmountFormatted(litres, 1_000_000, "ML");
-        }
-        if (litres >= 1_000) {
-            return getRoundedAmountFormatted(litres, 1_000, "kL");
-        }
-        return litres + " L";
-    }
-
-    private String getRoundedAmountFormatted(long litres, long scale, String unit) {
-        final long roundedTenths = (litres * 10 + scale / 2) / scale;
-        final long integerPart = roundedTenths / 10;
-        final long decimalDigit = roundedTenths % 10;
-        if (decimalDigit == 0) {
-            return integerPart + " " + unit;
-        }
-        return integerPart + "." + decimalDigit + " " + unit;
+        return amount + " L/op";
     }
 }


### PR DESCRIPTION
## Summary
~Turn out GT divide by 5000 the value it send to VP https://github.com/GTNewHorizons/GT5-Unofficial/blob/master/src/main/java/gregtech/common/UndergroundOil.java#L34
Which is why the overlay is so weird to read.~

~This multiply it back by the same `DIVIDER` value (grabbed from GT so if it change it should follow).~

Ok I was wrong, see comment below.

## Checklist
- [X] I have tested this PR in DevEnv
- [ ] I have tested this PR in Fullpack
- [X] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
Codex was used
- [ ] This PR requires another PR in order to merge
