### PR TITLE
Fix incorrect oregen pattern being used in some case. Attempt to autofix wrong entries in cache

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -1,7 +1,7 @@
 dependencies {
     api('com.github.GTNewHorizons:Navigator:1.1.4:dev')
     api('com.github.GTNewHorizons:GTNHLib:0.11.23:dev')
-    api('com.github.GTNewHorizons:GT5-Unofficial:5.09.54.15:dev')
+    api('com.github.GTNewHorizons:GT5-Unofficial:5.09.54.29:dev')
     api('com.github.GTNewHorizons:NotEnoughItems:2.8.110-GTNH:dev')
 
     compileOnlyApi('com.github.GTNewHorizons:Galacticraft:3.4.31-GTNH:dev') { transitive = false }

--- a/src/main/java/com/sinthoras/visualprospecting/Utils.java
+++ b/src/main/java/com/sinthoras/visualprospecting/Utils.java
@@ -40,9 +40,7 @@ import com.sinthoras.visualprospecting.hooks.HooksClient;
 import codechicken.nei.NEIClientConfig;
 import codechicken.nei.SearchField;
 import codechicken.nei.api.ItemFilter;
-import cpw.mods.fml.common.FMLCommonHandler;
 import cpw.mods.fml.common.Loader;
-import cpw.mods.fml.relauncher.Side;
 import gregtech.common.GTWorldgenerator;
 
 @SuppressWarnings("ResultOfMethodCallIgnored")
@@ -65,9 +63,7 @@ public class Utils {
     }
 
     public static int mapToCenterOreChunkCoord(final int chunkCoord) {
-        GTWorldgenerator.OregenPattern pattern = FMLCommonHandler.instance().getEffectiveSide() == Side.SERVER
-                ? GTWorldgenerator.getServerOregenPattern()
-                : GTWorldgenerator.getClientOregenPattern();
+        GTWorldgenerator.OregenPattern pattern = GTWorldgenerator.getOregenPattern();
         if (pattern == GTWorldgenerator.OregenPattern.EQUAL_SPACING) {
             // new evenly spaced ore pattern
             return chunkCoord - Math.floorMod(chunkCoord, 3) + 1;

--- a/src/main/java/com/sinthoras/visualprospecting/database/DimensionCache.java
+++ b/src/main/java/com/sinthoras/visualprospecting/database/DimensionCache.java
@@ -71,6 +71,7 @@ public class DimensionCache {
     public final int dimensionId;
     private boolean isDirty = false;
     private boolean preventSaving = false;
+    private boolean requiresOreRescan = false;
 
     public DimensionCache(int dimensionId) {
         this.dimensionId = dimensionId;
@@ -127,6 +128,9 @@ public class DimensionCache {
         oreChunks.ensureCapacity(oreChunks.size() + size);
 
         int unknownVeinTypes = 0;
+        int repairedCoordinates = 0;
+        int discardedRescans = 0;
+        int collapsedDuplicates = 0;
         for (int i = 0; i < size; i++) {
             int index = veinTypeIndexArray[i];
             if (index < 0 || index >= palette.length) {
@@ -139,21 +143,50 @@ public class DimensionCache {
                 continue;
             }
             VeinSource source = VeinSource.fromByte(sourceArray[i]);
-            oreChunks.put(
-                    getOreVeinKey(chunkXArray[i], chunkZArray[i]),
-                    new OreVeinPosition(
-                            dimensionId,
-                            chunkXArray[i],
-                            chunkZArray[i],
-                            veinType,
-                            depletedArray[i] == 1,
-                            source));
+            OreVeinPosition position = new OreVeinPosition(
+                    dimensionId,
+                    chunkXArray[i],
+                    chunkZArray[i],
+                    veinType,
+                    depletedArray[i] == 1,
+                    source);
+            if (position.chunkX != chunkXArray[i] || position.chunkZ != chunkZArray[i]) {
+                repairedCoordinates++;
+                if (source == VeinSource.RESCAN) {
+                    discardedRescans++;
+                    requiresOreRescan = true;
+                    continue;
+                }
+            }
+            long key = getOreVeinKey(position.chunkX, position.chunkZ);
+            OreVeinPosition stored = oreChunks.get(key);
+            if (stored == null) {
+                oreChunks.put(key, position);
+            } else {
+                collapsedDuplicates++;
+                if (position.getSource().canOverwrite(stored.getSource())) {
+                    oreChunks.put(key, position.joinDepletedState(stored));
+                } else {
+                    stored.joinDepletedState(position);
+                }
+            }
         }
         if (unknownVeinTypes > 0) {
             VP.LOG.warn(
                     "Dimension {}: skipped {} entries with unknown vein type names while loading cache.",
                     dimensionId,
                     unknownVeinTypes);
+        }
+        if (repairedCoordinates > 0) {
+            markDirty();
+            VP.LOG.warn(
+                    "Dimension {}: found {} misaligned ore vein cache coordinates, repaired {}, discarded {} entries "
+                            + "that require a rescan, and collapsed {} duplicates. The cache will be rewritten.",
+                    dimensionId,
+                    repairedCoordinates,
+                    repairedCoordinates - discardedRescans,
+                    discardedRescans,
+                    collapsedDuplicates);
         }
     }
 
@@ -335,6 +368,10 @@ public class DimensionCache {
 
     boolean hasFluids() {
         return !undergroundFluids.isEmpty();
+    }
+
+    boolean requiresOreRescan() {
+        return requiresOreRescan;
     }
 
     void markPreventSaving() {

--- a/src/main/java/com/sinthoras/visualprospecting/database/WorldCache.java
+++ b/src/main/java/com/sinthoras/visualprospecting/database/WorldCache.java
@@ -35,6 +35,7 @@ public abstract class WorldCache {
         if (dimensionFiles == null || dimensionFiles.length == 0) return false;
 
         boolean loadedAny = false;
+        boolean requiresOreRescan = false;
         for (File dimensionFile : dimensionFiles) {
             final String fileName = dimensionFile.getName();
             if (!dimensionFile.isFile() || !fileName.endsWith(".dat")) {
@@ -47,10 +48,11 @@ public abstract class WorldCache {
             final int dimensionId = dimCompound.getInteger("dim");
             final DimensionCache dimension = dimensions.computeIfAbsent(dimensionId, DimensionCache::new);
             dimension.loadFromNbt(dimCompound);
+            requiresOreRescan |= dimension.requiresOreRescan();
             loadedAny = true;
         }
 
-        return loadedAny;
+        return loadedAny && !requiresOreRescan;
     }
 
     private boolean loadLegacyVeinCache(File worldCacheDirectory) {

--- a/src/main/java/com/sinthoras/visualprospecting/teams/TeamCatchupHandler.java
+++ b/src/main/java/com/sinthoras/visualprospecting/teams/TeamCatchupHandler.java
@@ -87,6 +87,7 @@ public final class TeamCatchupHandler {
 
         TeamProspectionData data = (TeamProspectionData) surviving.getData(TeamProspectionData.DATA_KEY);
         if (data == null) return;
+        markRepairedTeamDataDirty(surviving, data);
 
         // Update every player with new merged data, only for dimensions they visited since login
         TeamManager.forEachOnlineTeamMember(surviving, member -> {
@@ -111,6 +112,7 @@ public final class TeamCatchupHandler {
         if (team == null) return;
         TeamProspectionData data = (TeamProspectionData) team.getData(TeamProspectionData.DATA_KEY);
         if (data == null) return;
+        markRepairedTeamDataDirty(team, data);
 
         sendDimVeins(player, data, dim);
         sendDimFluids(player, data, dim);
@@ -186,5 +188,12 @@ public final class TeamCatchupHandler {
     private static void flushFluids(EntityPlayerMP player, List<UndergroundFluidPosition> batch) {
         if (batch.isEmpty()) return;
         VP.network.sendTo(TeamCatchupNotification.fluids(batch), player);
+    }
+
+    private static void markRepairedTeamDataDirty(Team team, TeamProspectionData data) {
+        if (data.consumeRepairedVeinCoordinates()) {
+            team.markDirty();
+            VP.LOG.warn("Repaired ore vein coordinates in team prospection data for the current oregen pattern.");
+        }
     }
 }

--- a/src/main/java/com/sinthoras/visualprospecting/teams/TeamProspectionData.java
+++ b/src/main/java/com/sinthoras/visualprospecting/teams/TeamProspectionData.java
@@ -19,6 +19,7 @@ import com.gtnewhorizon.gtnhlib.teams.ITeamData;
 import com.gtnewhorizon.gtnhlib.teams.Team;
 import com.gtnewhorizon.gtnhlib.teams.TeamDataTransferReason;
 import com.sinthoras.visualprospecting.Config;
+import com.sinthoras.visualprospecting.Utils;
 import com.sinthoras.visualprospecting.VP;
 
 import it.unimi.dsi.fastutil.ints.Int2ObjectMap;
@@ -57,6 +58,7 @@ public class TeamProspectionData implements ITeamData {
     private Int2ObjectMap<LongSet> depletedVeins;
     // Team Data - Status
     private boolean expanded;
+    private boolean repairedVeinCoordinates;
     private byte[] unknownVersionBlob;
     private int unknownVersion;
 
@@ -75,7 +77,41 @@ public class TeamProspectionData implements ITeamData {
             }
             pendingBlob = null;
         }
+        repairedVeinCoordinates = normalizeVeinCoordinates(discoveredVeins) | normalizeVeinCoordinates(depletedVeins);
         expanded = true;
+    }
+
+    public boolean consumeRepairedVeinCoordinates() {
+        ensureExpanded();
+        boolean repaired = repairedVeinCoordinates;
+        repairedVeinCoordinates = false;
+        return repaired;
+    }
+
+    private static boolean normalizeVeinCoordinates(Int2ObjectMap<LongSet> veins) {
+        boolean repaired = false;
+        for (LongSet keys : veins.values()) {
+            long[] oldKeys = keys.toLongArray();
+            boolean changed = false;
+            for (long key : oldKeys) {
+                if (veinChunkX(key) != Utils.mapToCenterOreChunkCoord(veinChunkX(key))
+                        || veinChunkZ(key) != Utils.mapToCenterOreChunkCoord(veinChunkZ(key))) {
+                    changed = true;
+                    break;
+                }
+            }
+            if (!changed) continue;
+
+            keys.clear();
+            for (long key : oldKeys) {
+                keys.add(
+                        packVein(
+                                Utils.mapToCenterOreChunkCoord(veinChunkX(key)),
+                                Utils.mapToCenterOreChunkCoord(veinChunkZ(key))));
+            }
+            repaired = true;
+        }
+        return repaired;
     }
 
     // Pack an Ore vein position
@@ -135,6 +171,7 @@ public class TeamProspectionData implements ITeamData {
         discoveredVeins = new Int2ObjectOpenHashMap<>();
         discoveredFluids = new Int2ObjectOpenHashMap<>();
         depletedVeins = new Int2ObjectOpenHashMap<>();
+        repairedVeinCoordinates = false;
         expanded = true;
     }
 
@@ -203,6 +240,7 @@ public class TeamProspectionData implements ITeamData {
         discoveredVeins = null;
         discoveredFluids = null;
         depletedVeins = null;
+        repairedVeinCoordinates = false;
 
         if (!tag.hasKey(TAG_BLOB, Constants.NBT.TAG_STRING)) return;
         int version = tag.getInteger(TAG_VERSION);


### PR DESCRIPTION
## Summary
Requires https://github.com/GTNewHorizons/GT5-Unofficial/pull/7405 (Merged already)
Replaces https://github.com/GTNewHorizons/VisualProspecting/pull/98

Use GT5's freshly added `GTWorldgenerator.getOregenPattern()` instead of determining the logical side inside VisualProspecting.

Affected cache data is repaired while loading:
- Server and client cache coordinates are normalised to the current world pattern
- If this end up with coord collisions preserve the one with the highest VeinSource trust level
- Discard misaligned `RESCAN` entries because their vein type was inferred from the wrong physical chunk. In that case trigger a forced rescan of these entries.
- Also normalise the team cache to ensure it doesn't have wrong coord stored


## Checklist
- [x] I have tested this PR in DevEnv
- [x] I have tested this PR in Fullpack
- [x] I have tested this PR in Fullpack + Dedicated server
- [x] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
