### PR TITLE
trust the mapping of min & max during ore chunk prospecting

### DIFF
--- a/src/main/java/com/sinthoras/visualprospecting/database/ServerCache.java
+++ b/src/main/java/com/sinthoras/visualprospecting/database/ServerCache.java
@@ -90,8 +90,8 @@ public class ServerCache extends WorldCache {
         maxChunkZ = Utils.mapToCenterOreChunkCoord(maxChunkZ);
 
         List<OreVeinPosition> oreVeinPositions = new ArrayList<>();
-        for (int chunkX = minChunkX; chunkX <= maxChunkX; chunkX = Utils.mapToCenterOreChunkCoord(chunkX + 3)) {
-            for (int chunkZ = minChunkZ; chunkZ <= maxChunkZ; chunkZ = Utils.mapToCenterOreChunkCoord(chunkZ + 3)) {
+        for (int chunkX = minChunkX; chunkX <= maxChunkX; chunkX += VP.oreVeinSizeChunkX) {
+            for (int chunkZ = minChunkZ; chunkZ <= maxChunkZ; chunkZ += VP.oreVeinSizeChunkZ) {
                 final OreVeinPosition oreVeinPosition = getOreVein(dimensionId, chunkX, chunkZ);
                 if (oreVeinPosition.veinType != VeinType.NO_VEIN) {
                     oreVeinPositions.add(oreVeinPosition);


### PR DESCRIPTION
## Summary
if the mapping of min/max for x & z works, then clearly the offets will always be mapped as well
also use the existing constant instead of random magic number
i randomly found this while also dealing with the broken prospecting

## Checklist
- [ ] I have tested this PR in DevEnv
- [ ] I have tested this PR in Fullpack
- [x] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
- [ ] This PR requires another PR in order to merge
