### PR TITLE
Fix Xaeros culling regression

### DIFF
--- a/src/main/java/com/sinthoras/visualprospecting/integration/model/render/OreVeinRenderStep.java
+++ b/src/main/java/com/sinthoras/visualprospecting/integration/model/render/OreVeinRenderStep.java
@@ -43,13 +43,16 @@ public class OreVeinRenderStep extends UniversalInteractableStep<OreVeinLocation
 
     @Override
     public void draw(double topX, double topY, float drawScale, double zoom) {
-        final Minecraft mc = Minecraft.getMinecraft();
-        final double scale = isXaero && shouldScale ? getScaling(zoom) : 1.0;
-        final double screenW = mc.displayWidth * scale;
-        final double screenH = mc.displayHeight * scale;
-        final double topMargin = (fontHeight + 5) * getFontScale() * scale;
-        if (topX + width < 0 || topX > screenW || topY + height < -topMargin || topY > screenH) {
-            return;
+        // Xaero culling relies on Navigator's visible cache; add centered bounds if that cache grows costly.
+        if (!isXaero) {
+            final Minecraft mc = Minecraft.getMinecraft();
+            final double scale = 1.0;
+            final double screenW = mc.displayWidth * scale;
+            final double screenH = mc.displayHeight * scale;
+            final double topMargin = (fontHeight + 5) * getFontScale() * scale;
+            if (topX + width < 0 || topX > screenW || topY + height < -topMargin || topY > screenH) {
+                return;
+            }
         }
 
         if (zoom >= Config.minZoomLevelForOreLabel && !location.isDepleted()) {

--- a/src/main/java/com/sinthoras/visualprospecting/integration/model/render/UndergroundFluidRenderStep.java
+++ b/src/main/java/com/sinthoras/visualprospecting/integration/model/render/UndergroundFluidRenderStep.java
@@ -25,7 +25,9 @@ public class UndergroundFluidRenderStep extends UniversalRenderStep<UndergroundF
         final Minecraft mc = Minecraft.getMinecraft();
         final double regionW = VP.undergroundFluidSizeChunkX * VP.chunkWidth * blockSize;
         final double regionH = VP.undergroundFluidSizeChunkZ * VP.chunkWidth * blockSize;
-        if (topX + regionW < 0 || topY + regionH < 0 || topX > mc.displayWidth || topY > mc.displayHeight) {
+        // Xaero culling relies on Navigator's visible cache; add centered bounds if that cache grows costly.
+        if (!isXaero
+                && (topX + regionW < 0 || topY + regionH < 0 || topX > mc.displayWidth || topY > mc.displayHeight)) {
             return;
         }
 
@@ -89,10 +91,10 @@ public class UndergroundFluidRenderStep extends UniversalRenderStep<UndergroundF
         final double cellH = getAdjustedHeight();
         for (int chunkX = 0; chunkX < VP.undergroundFluidSizeChunkX; chunkX++) {
             final double cellX = x + chunkX * cellW;
-            if (cellX + cellW < 0 || cellX > screenW) continue;
+            if (!isXaero && (cellX + cellW < 0 || cellX > screenW)) continue;
             for (int chunkZ = 0; chunkZ < VP.undergroundFluidSizeChunkZ; chunkZ++) {
                 final double cellY = y + chunkZ * cellH;
-                if (cellY + cellH < 0 || cellY > screenH) continue;
+                if (!isXaero && (cellY + cellH < 0 || cellY > screenH)) continue;
                 int amount = chunks[chunkX][chunkZ];
                 if (amount <= 0) continue;
                 int alpha = productionRange > 1 ? (int) ((amount - minProduction) / productionRange * 255) : 10;


### PR DESCRIPTION
## Summary
Fixes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/25941
Regression caused by my PR #89

Change it back so that the culling for journeymap-legacy doesn't apply to Xaeros since it's causing issue.

Cherry picked from my JM6 support branch, quickly making a PR for it since someone ran into the issue and I already had code ready.
Tested full pack on JM5 and Xaeros, doesn't seem to cause additional issues.


## Checklist
- [x] I have tested this PR in DevEnv
- [x] I have tested this PR in Fullpack
- [x] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
