### PR TITLE
Add Additional API for Finding Depleted Veins and Updating Clients

### DIFF
--- a/src/main/java/com/sinthoras/visualprospecting/VisualProspecting_API.java
+++ b/src/main/java/com/sinthoras/visualprospecting/VisualProspecting_API.java
@@ -100,6 +100,11 @@ public class VisualProspecting_API {
             TeamProspectionDispatcher.deliverProspectingResults(player, oreVeins, undergroundFluids);
         }
 
+        public static void sendProspectionResultsToClient(UUID player, List<OreVeinPosition> oreVeins,
+                List<UndergroundFluidPosition> undergroundFluids) {
+            TeamProspectionDispatcher.deliverProspectingResults(player, oreVeins, undergroundFluids);
+        }
+
         public static List<OreVeinPosition> prospectOreVeinsWithinRadius(int dimensionId, int blockX, int blockZ,
                 int blockRadius) {
             return ServerCache.instance.prospectOreBlockRadius(dimensionId, blockX, blockZ, blockRadius);

--- a/src/main/java/com/sinthoras/visualprospecting/VisualProspecting_API.java
+++ b/src/main/java/com/sinthoras/visualprospecting/VisualProspecting_API.java
@@ -88,8 +88,8 @@ public class VisualProspecting_API {
         }
 
         public static boolean isVeinDepleted(World world, int dimensionId, int chunkX, int chunkZ, int chunkRadius) {
-            final int centerX = Utils.mapToCenterOreChunkCoord(chunkX << 4) >> 4;
-            final int centerZ = Utils.mapToCenterOreChunkCoord(chunkZ << 4) >> 4;
+            final int centerX = Utils.mapToCenterOreChunkCoord(chunkX);
+            final int centerZ = Utils.mapToCenterOreChunkCoord(chunkZ);
 
             final ReferenceOpenHashSet<IOreMaterial> presentOreMaterials = new ReferenceOpenHashSet<>();
             final VeinType veinType = ServerCache.instance.getOreVein(dimensionId, chunkX, chunkZ).veinType;

--- a/src/main/java/com/sinthoras/visualprospecting/VisualProspecting_API.java
+++ b/src/main/java/com/sinthoras/visualprospecting/VisualProspecting_API.java
@@ -2,6 +2,7 @@ package com.sinthoras.visualprospecting;
 
 import java.util.Collections;
 import java.util.List;
+import java.util.UUID;
 
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.entity.player.EntityPlayerMP;
@@ -12,12 +13,16 @@ import com.sinthoras.visualprospecting.database.OreVeinPosition;
 import com.sinthoras.visualprospecting.database.ServerCache;
 import com.sinthoras.visualprospecting.database.UndergroundFluidPosition;
 import com.sinthoras.visualprospecting.database.VeinSource;
+import com.sinthoras.visualprospecting.database.cachebuilder.PartiallyLoadedChunk;
+import com.sinthoras.visualprospecting.database.veintypes.VeinType;
 import com.sinthoras.visualprospecting.database.veintypes.VeinTypeCaching;
 import com.sinthoras.visualprospecting.network.VeinDepletionMessage;
 import com.sinthoras.visualprospecting.teams.TeamProspectionDispatcher;
 
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
+import gregtech.api.interfaces.IOreMaterial;
+import it.unimi.dsi.fastutil.objects.ReferenceOpenHashSet;
 
 @SuppressWarnings("unused")
 public class VisualProspecting_API {
@@ -80,6 +85,28 @@ public class VisualProspecting_API {
                     dimensionId,
                     Utils.mapToCenterOreChunkCoord(blockX),
                     Utils.mapToCenterOreChunkCoord(blockZ));
+        }
+
+        public static boolean isVeinDepleted(World world, int dimensionId, int chunkX, int chunkZ, int chunkRadius) {
+            final int centerX = Utils.mapToCenterOreChunkCoord(chunkX << 4) >> 4;
+            final int centerZ = Utils.mapToCenterOreChunkCoord(chunkZ << 4) >> 4;
+
+            final ReferenceOpenHashSet<IOreMaterial> presentOreMaterials = new ReferenceOpenHashSet<>();
+            final VeinType veinType = ServerCache.instance.getOreVein(dimensionId, chunkX, chunkZ).veinType;
+
+            for (int curX = centerX - chunkRadius; curX <= centerX + chunkRadius; curX++) {
+                for (int curZ = centerZ - chunkRadius; curZ <= centerZ + chunkRadius; curZ++) {
+                    final PartiallyLoadedChunk chunk = new PartiallyLoadedChunk();
+                    chunk.loadFromLiveChunk(world.getChunkFromChunkCoords(curX, curZ));
+                    chunk.forEachOre((x, y, z, info) -> presentOreMaterials.add(info.material));
+                }
+            }
+
+            for (IOreMaterial oreMaterial : presentOreMaterials) {
+                if (VeinTypeCaching.getVeinTypesForOre(oreMaterial).contains(veinType)) return false;
+            }
+
+            return true;
         }
 
         public static UndergroundFluidPosition getUndergroundFluid(World world, int blockX, int blockZ) {

--- a/src/main/java/com/sinthoras/visualprospecting/database/ServerCache.java
+++ b/src/main/java/com/sinthoras/visualprospecting/database/ServerCache.java
@@ -1,6 +1,5 @@
 package com.sinthoras.visualprospecting.database;
 
-import static com.sinthoras.visualprospecting.VisualProspecting_API.LogicalClient.setOreVeinDepleted;
 import static com.sinthoras.visualprospecting.VisualProspecting_API.LogicalServer.isVeinDepleted;
 import static com.sinthoras.visualprospecting.VisualProspecting_API.LogicalServer.sendProspectionResultsToClient;
 
@@ -9,15 +8,14 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
-import com.gtnewhorizon.gtnhlib.teams.Team;
-import com.gtnewhorizon.gtnhlib.teams.TeamManager;
-import com.sinthoras.visualprospecting.teams.TeamProspectionData;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.entity.player.EntityPlayerMP;
 import net.minecraft.world.World;
 import net.minecraftforge.fluids.Fluid;
 import net.minecraftforge.fluids.FluidStack;
 
+import com.gtnewhorizon.gtnhlib.teams.Team;
+import com.gtnewhorizon.gtnhlib.teams.TeamManager;
 import com.sinthoras.visualprospecting.Config;
 import com.sinthoras.visualprospecting.Tags;
 import com.sinthoras.visualprospecting.Utils;
@@ -26,6 +24,7 @@ import com.sinthoras.visualprospecting.database.veintypes.VeinType;
 import com.sinthoras.visualprospecting.database.veintypes.VeinTypeCaching;
 import com.sinthoras.visualprospecting.network.ProspectingNotification;
 import com.sinthoras.visualprospecting.network.ProspectingRequest;
+import com.sinthoras.visualprospecting.teams.TeamProspectionData;
 import com.sinthoras.visualprospecting.teams.TeamProspectionDispatcher;
 
 import cpw.mods.fml.common.eventhandler.SubscribeEvent;

--- a/src/main/java/com/sinthoras/visualprospecting/database/ServerCache.java
+++ b/src/main/java/com/sinthoras/visualprospecting/database/ServerCache.java
@@ -1,7 +1,12 @@
 package com.sinthoras.visualprospecting.database;
 
+import static com.sinthoras.visualprospecting.VisualProspecting_API.LogicalClient.setOreVeinDepleted;
+import static com.sinthoras.visualprospecting.VisualProspecting_API.LogicalServer.isVeinDepleted;
+import static com.sinthoras.visualprospecting.VisualProspecting_API.LogicalServer.sendProspectionResultsToClient;
+
 import java.io.File;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 import net.minecraft.entity.player.EntityPlayer;
@@ -21,6 +26,7 @@ import com.sinthoras.visualprospecting.network.ProspectingRequest;
 import com.sinthoras.visualprospecting.teams.TeamProspectionDispatcher;
 
 import cpw.mods.fml.common.eventhandler.SubscribeEvent;
+import gregtech.api.events.DrillChunkDiscoveryEvent;
 import gregtech.api.events.OreInteractEvent;
 import gregtech.api.events.VeinGenerateEvent;
 import gregtech.api.interfaces.IOreMaterial;
@@ -80,6 +86,27 @@ public class ServerCache extends WorldCache {
                 TeamProspectionDispatcher.deliverProspectingResults((EntityPlayerMP) player, response);
             }
         }
+    }
+
+    @SubscribeEvent
+    public void onDrillChunkDiscovery(DrillChunkDiscoveryEvent event) {
+        final boolean depleted = isVeinDepleted(
+                event.world,
+                event.world.provider.dimensionId,
+                event.chunkX,
+                event.chunkZ,
+                1);
+
+        final OreVeinPosition vein = getOreVein(event.world.provider.dimensionId, event.chunkX, event.chunkZ);
+
+        if (depleted && !vein.isDepleted()) vein.toggleDepleted();
+
+        sendProspectionResultsToClient(event.owner, Collections.singletonList(vein), Collections.emptyList());
+
+        if (depleted) {
+            setOreVeinDepleted(event.world.provider.dimensionId, event.chunkX << 4, event.chunkZ << 4);
+        }
+
     }
 
     public List<OreVeinPosition> prospectOreChunks(int dimensionId, int minChunkX, int minChunkZ, int maxChunkX,

--- a/src/main/java/com/sinthoras/visualprospecting/database/ServerCache.java
+++ b/src/main/java/com/sinthoras/visualprospecting/database/ServerCache.java
@@ -9,6 +9,9 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
+import com.gtnewhorizon.gtnhlib.teams.Team;
+import com.gtnewhorizon.gtnhlib.teams.TeamManager;
+import com.sinthoras.visualprospecting.teams.TeamProspectionData;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.entity.player.EntityPlayerMP;
 import net.minecraft.world.World;
@@ -103,10 +106,14 @@ public class ServerCache extends WorldCache {
 
         sendProspectionResultsToClient(event.owner, Collections.singletonList(vein), Collections.emptyList());
 
-        if (depleted) {
-            setOreVeinDepleted(event.world.provider.dimensionId, event.chunkX << 4, event.chunkZ << 4);
-        }
+        Team team = TeamManager.getTeamByPlayer(event.owner);
+        if (team == null) return;
+        TeamProspectionData data = (TeamProspectionData) team.getData(TeamProspectionData.DATA_KEY);
+        if (data == null) return;
 
+        if (depleted) {
+            data.setVeinDepleted(event.world.provider.dimensionId, event.chunkX << 4, event.chunkZ << 4, true);
+        }
     }
 
     public List<OreVeinPosition> prospectOreChunks(int dimensionId, int minChunkX, int minChunkZ, int maxChunkX,

--- a/src/main/java/com/sinthoras/visualprospecting/database/ServerCache.java
+++ b/src/main/java/com/sinthoras/visualprospecting/database/ServerCache.java
@@ -14,8 +14,6 @@ import net.minecraft.world.World;
 import net.minecraftforge.fluids.Fluid;
 import net.minecraftforge.fluids.FluidStack;
 
-import com.gtnewhorizon.gtnhlib.teams.Team;
-import com.gtnewhorizon.gtnhlib.teams.TeamManager;
 import com.sinthoras.visualprospecting.Config;
 import com.sinthoras.visualprospecting.Tags;
 import com.sinthoras.visualprospecting.Utils;
@@ -24,7 +22,6 @@ import com.sinthoras.visualprospecting.database.veintypes.VeinType;
 import com.sinthoras.visualprospecting.database.veintypes.VeinTypeCaching;
 import com.sinthoras.visualprospecting.network.ProspectingNotification;
 import com.sinthoras.visualprospecting.network.ProspectingRequest;
-import com.sinthoras.visualprospecting.teams.TeamProspectionData;
 import com.sinthoras.visualprospecting.teams.TeamProspectionDispatcher;
 
 import cpw.mods.fml.common.eventhandler.SubscribeEvent;
@@ -92,27 +89,24 @@ public class ServerCache extends WorldCache {
 
     @SubscribeEvent
     public void onDrillChunkDiscovery(DrillChunkDiscoveryEvent event) {
+        if (!event.discovery) return;
+        final OreVeinPosition vein = getOreVein(event.world.provider.dimensionId, event.chunkX, event.chunkZ);
+        sendProspectionResultsToClient(event.owner, Collections.singletonList(vein), Collections.emptyList());
+    }
+
+    @SubscribeEvent
+    public void onDrillChunkDepletion(DrillChunkDiscoveryEvent event) {
+        if (event.discovery) return;
         final boolean depleted = isVeinDepleted(
                 event.world,
                 event.world.provider.dimensionId,
                 event.chunkX,
                 event.chunkZ,
                 1);
-
-        final OreVeinPosition vein = getOreVein(event.world.provider.dimensionId, event.chunkX, event.chunkZ);
-
-        if (depleted && !vein.isDepleted()) vein.toggleDepleted();
-
-        sendProspectionResultsToClient(event.owner, Collections.singletonList(vein), Collections.emptyList());
-
-        if (!depleted) return;
-
-        Team team = TeamManager.getTeamByPlayer(event.owner);
-        if (team == null) return;
-        TeamProspectionData data = (TeamProspectionData) team.getData(TeamProspectionData.DATA_KEY);
-        if (data == null) return;
-
-        data.setVeinDepleted(event.world.provider.dimensionId, event.chunkX, event.chunkZ, true);
+        final int centerX = Utils.mapToCenterOreChunkCoord(event.chunkX);
+        final int centerZ = Utils.mapToCenterOreChunkCoord(event.chunkZ);
+        TeamProspectionDispatcher
+                .handleDepletionToggle(event.owner, event.world.provider.dimensionId, centerX, centerZ, depleted);
     }
 
     public List<OreVeinPosition> prospectOreChunks(int dimensionId, int minChunkX, int minChunkZ, int maxChunkX,

--- a/src/main/java/com/sinthoras/visualprospecting/database/ServerCache.java
+++ b/src/main/java/com/sinthoras/visualprospecting/database/ServerCache.java
@@ -105,14 +105,14 @@ public class ServerCache extends WorldCache {
 
         sendProspectionResultsToClient(event.owner, Collections.singletonList(vein), Collections.emptyList());
 
+        if (!depleted) return;
+
         Team team = TeamManager.getTeamByPlayer(event.owner);
         if (team == null) return;
         TeamProspectionData data = (TeamProspectionData) team.getData(TeamProspectionData.DATA_KEY);
         if (data == null) return;
 
-        if (depleted) {
-            data.setVeinDepleted(event.world.provider.dimensionId, event.chunkX << 4, event.chunkZ << 4, true);
-        }
+        data.setVeinDepleted(event.world.provider.dimensionId, event.chunkX, event.chunkZ, true);
     }
 
     public List<OreVeinPosition> prospectOreChunks(int dimensionId, int minChunkX, int minChunkZ, int maxChunkX,

--- a/src/main/java/com/sinthoras/visualprospecting/teams/TeamProspectionDispatcher.java
+++ b/src/main/java/com/sinthoras/visualprospecting/teams/TeamProspectionDispatcher.java
@@ -3,6 +3,7 @@ package com.sinthoras.visualprospecting.teams;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.UUID;
 
 import net.minecraft.entity.player.EntityPlayerMP;
 
@@ -40,6 +41,40 @@ public final class TeamProspectionDispatcher {
 
     public static void deliverProspectingResults(EntityPlayerMP player, ProspectingNotification notification) {
         deliverProspectingResults(player, notification, true);
+    }
+
+    /**
+     * Send prospection results to {@code player}'s team through UUID.
+     *
+     * @param player   the player's team whose action produced these results
+     * @param oreVeins ore veins to deliver. May be empty; must not be {@code null}.
+     * @param fluids   underground fluid positions to deliver. May be empty; must not be {@code null}.
+     */
+    public static void deliverProspectingResults(UUID player, List<OreVeinPosition> oreVeins,
+            List<UndergroundFluidPosition> fluids) {
+        deliverProspectingResults(player, new ProspectingNotification(oreVeins, fluids));
+    }
+
+    public static void deliverProspectingResults(UUID player, ProspectingNotification notification) {
+        if (player == null) return;
+
+        if (!Config.enableTeamSharing) return;
+
+        Team team = TeamManager.getTeamByPlayer(player);
+        if (team == null) return;
+        TeamProspectionData data = (TeamProspectionData) team.getData(TeamProspectionData.DATA_KEY);
+        if (data == null) return;
+
+        // Update the team's record
+        List<OreVeinPosition> newVeins = filterNewVeins(data, notification.getOreVeins());
+        List<UndergroundFluidPosition> newFluids = filterNewFluids(data, notification.getUndergroundFluids());
+        if (newVeins.isEmpty() && newFluids.isEmpty()) return;
+
+        team.markDirty();
+
+        // Broadcast to other online teammates.
+        ProspectingNotification broadcast = new ProspectingNotification(newVeins, newFluids);
+        TeamManager.forEachOnlineTeamMember(team, member -> VP.network.sendTo(broadcast, member));
     }
 
     public static void deliverProspectingResults(EntityPlayerMP player, ProspectingNotification notification,

--- a/src/main/java/com/sinthoras/visualprospecting/teams/TeamProspectionDispatcher.java
+++ b/src/main/java/com/sinthoras/visualprospecting/teams/TeamProspectionDispatcher.java
@@ -141,6 +141,27 @@ public final class TeamProspectionDispatcher {
         });
     }
 
+    public static void handleDepletionToggle(UUID player, int dim, int chunkX, int chunkZ, boolean depleted) {
+        if (!Config.enableTeamSharing) return;
+
+        Team team = TeamManager.getTeamByPlayer(player);
+        if (team == null) return;
+        TeamProspectionData data = (TeamProspectionData) team.getData(TeamProspectionData.DATA_KEY);
+        if (data == null) return;
+
+        // Require the vein to be in the team's discovered set.
+        if (!data.isVeinDiscovered(dim, chunkX, chunkZ)) return;
+
+        // Stop here if the team's depletion state already matches.
+        if (!data.setVeinDepleted(dim, chunkX, chunkZ, depleted)) return;
+
+        team.markDirty();
+
+        // Broadcast to other online teammates.
+        VeinDepletionMessage broadcast = new VeinDepletionMessage(dim, chunkX, chunkZ, depleted);
+        TeamManager.forEachOnlineTeamMember(team, member -> VP.network.sendTo(broadcast, member));
+    }
+
     private static List<OreVeinPosition> filterNewVeins(TeamProspectionData data, List<OreVeinPosition> veins) {
         if (veins == null || veins.isEmpty()) return Collections.emptyList();
         List<OreVeinPosition> newVeins = new ArrayList<>(veins.size());


### PR DESCRIPTION
## Summary
<!-- Briefly describe what this PR changes and why. -->
This requires another PR to be merged to compile: [Add Prospecting & Depletion Marking to Multi Drills #7505](https://github.com/GTNewHorizons/GT5-Unofficial/pull/7505).

## Checklist
- [x] I have tested this PR in DevEnv
- [ ] I have tested this PR in Fullpack
- [x] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
- [x] This PR requires another PR in order to merge
