### PR TITLE
Relax a little bit the cache fallback command

### DIFF
--- a/src/main/java/com/sinthoras/visualprospecting/commands/admin/VPAdminDebugCommand.java
+++ b/src/main/java/com/sinthoras/visualprospecting/commands/admin/VPAdminDebugCommand.java
@@ -150,15 +150,15 @@ public class VPAdminDebugCommand {
 
         CommandHelpers.plain(sender, ANALYZE + "candidates_header", dominant.getLocalizedName(), candidates.size());
         int fullMatches = 0;
-        int sporadicIgnoredMatches = 0;
+        int oneMissingMatches = 0;
         for (VeinType candidate : candidates) {
             final boolean full = candidate.matchesWithSpecificPrimaryOrSecondary(oreCounts.keySet(), dimName, dominant);
-            final boolean ignoreSporadic = candidate.matchesIgnoringSporadic(oreCounts.keySet(), dimName, dominant);
+            final boolean oneMissing = candidate.matchesWithOneMissingOre(oreCounts.keySet(), dimName, dominant);
             if (full) fullMatches++;
-            if (ignoreSporadic) sporadicIgnoredMatches++;
-            CommandHelpers.plain(sender, ANALYZE + "candidate_line", candidate.name, full, ignoreSporadic);
+            if (oneMissing) oneMissingMatches++;
+            CommandHelpers.plain(sender, ANALYZE + "candidate_line", candidate.name, full, oneMissing);
         }
-        CommandHelpers.plain(sender, ANALYZE + "match_summary", fullMatches, sporadicIgnoredMatches);
+        CommandHelpers.plain(sender, ANALYZE + "match_summary", fullMatches, oneMissingMatches);
     }
 
     // Print Verdict

--- a/src/main/java/com/sinthoras/visualprospecting/database/cachebuilder/DetailedChunkAnalysis.java
+++ b/src/main/java/com/sinthoras/visualprospecting/database/cachebuilder/DetailedChunkAnalysis.java
@@ -135,13 +135,16 @@ public class DetailedChunkAnalysis {
                             .noneMatch(blockY -> isOreVeinGeneratedAtHeight(veinType, blockY)));
             return matchedVeins.size() == 1 ? matchedVeins.iterator().next() : VeinType.NO_VEIN;
         }
-        return matchIgnoringSporadic(allOres.keySet(), dominantOre);
+        if (ServerCache.instance.getOreVein(dimensionId, chunkX, chunkZ).veinType != VeinType.NO_VEIN) {
+            return VeinType.NO_VEIN;
+        }
+        return matchWithOneMissingOre(allOres.keySet(), dominantOre);
     }
 
-    private VeinType matchIgnoringSporadic(Set<IOreMaterial> foundOres, IOreMaterial dominantOre) {
+    private VeinType matchWithOneMissingOre(Set<IOreMaterial> foundOres, IOreMaterial dominantOre) {
         VeinType onlyMatch = VeinType.NO_VEIN;
         for (VeinType veinType : VeinTypeCaching.getVeinTypesForOre(dominantOre)) {
-            if (veinType.matchesIgnoringSporadic(foundOres, dimName, dominantOre)) {
+            if (veinType.matchesWithOneMissingOre(foundOres, dimName, dominantOre)) {
                 if (onlyMatch != VeinType.NO_VEIN) {
                     return VeinType.NO_VEIN;
                 }

--- a/src/main/java/com/sinthoras/visualprospecting/database/veintypes/VeinType.java
+++ b/src/main/java/com/sinthoras/visualprospecting/database/veintypes/VeinType.java
@@ -102,9 +102,11 @@ public class VeinType {
                 && foundOres.containsAll(oresAsSet);
     }
 
-    public boolean matchesWithOneMissingOre(Collection<IOreMaterial> foundOres, String dimName, IOreMaterial specific) {
+    public boolean matchesWithOneMissingOre(Collection<IOreMaterial> foundOres, String dimName,
+            IOreMaterial dominantOre) {
+        // Only match veins with four distinct ores when exactly three were found.
         if (oresAsSet.size() != 4 || foundOres.size() != 3) return false;
-        if (primaryOre != specific && secondaryOre != specific) return false;
+        if (primaryOre != dominantOre && secondaryOre != dominantOre) return false;
         if (!dimName.isEmpty() && !allowedDims.contains(dimName)) return false;
         return oresAsSet.containsAll(foundOres);
     }

--- a/src/main/java/com/sinthoras/visualprospecting/database/veintypes/VeinType.java
+++ b/src/main/java/com/sinthoras/visualprospecting/database/veintypes/VeinType.java
@@ -39,7 +39,6 @@ public class VeinType {
     public final int minBlockY;
     public final int maxBlockY;
     private final ReferenceOpenHashSet<IOreMaterial> oresAsSet = new ReferenceOpenHashSet<>();
-    private final ReferenceOpenHashSet<IOreMaterial> nonSporadicOres = new ReferenceOpenHashSet<>();
     private final List<List<IOreMaterial>> oresByLayer;
     private final List<String> allowedDims = new ArrayList<>();
     private boolean isHighlighted = true;
@@ -75,9 +74,6 @@ public class VeinType {
         oresAsSet.add(secondaryOre = oreMix.secondary);
         oresAsSet.add(inBetweenOre = oreMix.between);
         oresAsSet.add(sporadicOre = oreMix.sporadic);
-        nonSporadicOres.add(primaryOre);
-        nonSporadicOres.add(secondaryOre);
-        nonSporadicOres.add(inBetweenOre);
         oresByLayer = buildOresByLayer();
         minBlockY = Math.max(0, oreMix.minY - 6);
         maxBlockY = Math.min(255, oreMix.maxY - 6);
@@ -106,10 +102,11 @@ public class VeinType {
                 && foundOres.containsAll(oresAsSet);
     }
 
-    public boolean matchesIgnoringSporadic(Collection<IOreMaterial> foundOres, String dimName, IOreMaterial specific) {
-        return (primaryOre == specific || secondaryOre == specific)
-                && (dimName.isEmpty() || allowedDims.contains(dimName))
-                && foundOres.containsAll(nonSporadicOres);
+    public boolean matchesWithOneMissingOre(Collection<IOreMaterial> foundOres, String dimName, IOreMaterial specific) {
+        if (oresAsSet.size() != 4 || foundOres.size() != 3) return false;
+        if (primaryOre != specific && secondaryOre != specific) return false;
+        if (!dimName.isEmpty() && !allowedDims.contains(dimName)) return false;
+        return oresAsSet.containsAll(foundOres);
     }
 
     public List<String> getAllowedDimensions() {

--- a/src/main/resources/assets/visualprospecting/lang/en_US.lang
+++ b/src/main/resources/assets/visualprospecting/lang/en_US.lang
@@ -74,8 +74,8 @@ visualprospecting.command.vpadmin.debug.analyze.dominant=    Dominant: %s (x%s)
 visualprospecting.command.vpadmin.debug.analyze.no_dim_veins=    Note: dimension "%s" has no registered ore veins.
 visualprospecting.command.vpadmin.debug.analyze.candidates_none=    No candidate veins for the dominant ore.
 visualprospecting.command.vpadmin.debug.analyze.candidates_header=    Candidates for %s (%s):
-visualprospecting.command.vpadmin.debug.analyze.candidate_line=      %s [full=%s, ignoreSporadic=%s]
-visualprospecting.command.vpadmin.debug.analyze.match_summary=    Summary: %s full, %s sporadic-ignored
+visualprospecting.command.vpadmin.debug.analyze.candidate_line=      %s [full=%s, oneMissing=%s]
+visualprospecting.command.vpadmin.debug.analyze.match_summary=    Summary: %s full, %s one-missing
 visualprospecting.command.vpadmin.debug.analyze.resolved=    Resolved (detailed): %s (%s)
 visualprospecting.command.vpadmin.debug.analyze.resolved_none=    Resolved (detailed): none
 visualprospecting.command.vpadmin.debug.analyze.fastpath=    Fast-path (ChunkAnalysis): %s


### PR DESCRIPTION
## Summary
Fixes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/26059

Replace the fallback of the `/vp_admin servercache rebuild all` command.

It used to try to ignore sporadic ore if there was a single `OreMixes` candidate. Now it will try to match if one ore is missing regardless which one it is. But only if nothing is stored in cache for that spot.

## Checklist
- [x] I have tested this PR in DevEnv
- [x] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
